### PR TITLE
Update (R)IGM to use patch.

### DIFF
--- a/google-beta/resource_compute_instance_group_manager.go
+++ b/google-beta/resource_compute_instance_group_manager.go
@@ -480,10 +480,9 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 	}
 
 	if d.HasChange("auto_healing_policies") {
-		if v, ok := d.GetOk("auto_healing_policies"); ok {
-			updatedManager.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
-			change = true
-		}
+		updatedManager.AutoHealingPolicies = expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{}))
+		updatedManager.ForceSendFields = append(updatedManager.ForceSendFields, "AutoHealingPolicies")
+		change = true
 	}
 
 	if d.HasChange("version") {

--- a/google-beta/resource_compute_instance_group_manager.go
+++ b/google-beta/resource_compute_instance_group_manager.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/helper/validation"
 
 	computeBeta "google.golang.org/api/compute/v0.beta"
-	"google.golang.org/api/compute/v1"
+	compute "google.golang.org/api/compute/v1"
 )
 
 func resourceComputeInstanceGroupManager() *schema.Resource {
@@ -31,17 +31,9 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"instance_template": &schema.Schema{
-				Type:             schema.TypeString,
-				Optional:         true,
-				DiffSuppressFunc: compareSelfLinkRelativePaths,
-			},
-
 			"version": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
-				Type:       schema.TypeList,
-				Optional:   true,
-				Computed:   true,
+				Type:     schema.TypeList,
+				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -108,7 +100,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"named_port": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -135,22 +127,6 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-
-			"update_strategy": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "REPLACE",
-				ValidateFunc: validation.StringInSlice([]string{"RESTART", "NONE", "ROLLING_UPDATE", "REPLACE"}, false),
-				DiffSuppressFunc: func(key, old, new string, d *schema.ResourceData) bool {
-					if old == "REPLACE" && new == "RESTART" {
-						return true
-					}
-					if old == "RESTART" && new == "REPLACE" {
-						return true
-					}
-					return false
-				},
 			},
 
 			"target_pools": &schema.Schema{
@@ -190,11 +166,10 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				},
 			},
 
-			"rolling_update_policy": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
-				Type:       schema.TypeList,
-				Optional:   true,
-				MaxItems:   1,
+			"update_policy": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"minimal_action": &schema.Schema{
@@ -213,13 +188,13 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							Default:       1,
-							ConflictsWith: []string{"rolling_update_policy.0.max_surge_percent"},
+							ConflictsWith: []string{"update_policy.0.max_surge_percent"},
 						},
 
 						"max_surge_percent": &schema.Schema{
 							Type:          schema.TypeInt,
 							Optional:      true,
-							ConflictsWith: []string{"rolling_update_policy.0.max_surge_fixed"},
+							ConflictsWith: []string{"update_policy.0.max_surge_fixed"},
 							ValidateFunc:  validation.IntBetween(0, 100),
 						},
 
@@ -227,13 +202,13 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							Default:       1,
-							ConflictsWith: []string{"rolling_update_policy.0.max_unavailable_percent"},
+							ConflictsWith: []string{"update_policy.0.max_unavailable_percent"},
 						},
 
 						"max_unavailable_percent": &schema.Schema{
 							Type:          schema.TypeInt,
 							Optional:      true,
-							ConflictsWith: []string{"rolling_update_policy.0.max_unavailable_fixed"},
+							ConflictsWith: []string{"update_policy.0.max_unavailable_fixed"},
 							ValidateFunc:  validation.IntBetween(0, 100),
 						},
 
@@ -294,21 +269,18 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	if _, ok := d.GetOk("rolling_update_policy"); d.Get("update_strategy") == "ROLLING_UPDATE" && !ok {
-		return fmt.Errorf("[rolling_update_policy] must be set when 'update_strategy' is set to 'ROLLING_UPDATE'")
-	}
-
 	// Build the parameter
 	manager := &computeBeta.InstanceGroupManager{
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
 		BaseInstanceName:    d.Get("base_instance_name").(string),
-		InstanceTemplate:    d.Get("instance_template").(string),
 		TargetSize:          int64(d.Get("target_size").(int)),
-		NamedPorts:          getNamedPortsBeta(d.Get("named_port").([]interface{})),
+		NamedPorts:          getNamedPortsBeta(d.Get("named_port").(*schema.Set).List()),
 		TargetPools:         convertStringSet(d.Get("target_pools").(*schema.Set)),
 		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
 		Versions:            expandVersions(d.Get("version").([]interface{})),
+		UpdatePolicy:        expandUpdatePolicy(d.Get("update_policy").([]interface{})),
+
 		// Force send TargetSize to allow a value of 0.
 		ForceSendFields: []string{"TargetSize"},
 	}
@@ -431,7 +403,6 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	}
 
 	d.Set("base_instance_name", manager.BaseInstanceName)
-	d.Set("instance_template", ConvertSelfLinkToV1(manager.InstanceTemplate))
 	if err := d.Set("version", flattenVersions(manager.Versions)); err != nil {
 		return err
 	}
@@ -445,11 +416,6 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	d.Set("fingerprint", manager.Fingerprint)
 	d.Set("instance_group", ConvertSelfLinkToV1(manager.InstanceGroup))
 	d.Set("self_link", ConvertSelfLinkToV1(manager.SelfLink))
-	update_strategy, ok := d.GetOk("update_strategy")
-	if !ok {
-		update_strategy = "REPLACE"
-	}
-	d.Set("update_strategy", update_strategy.(string))
 	d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies))
 
 	if d.Get("wait_for_instances").(bool) {
@@ -460,63 +426,6 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 			Timeout: d.Timeout(schema.TimeoutCreate),
 		}
 		_, err := conf.WaitForState()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// Updates an instance group manager by applying the update strategy (REPLACE, RESTART)
-// and rolling update policy (PROACTIVE, OPPORTUNISTIC). Updates performed by API
-// are OPPORTUNISTIC by default.
-func performZoneUpdate(config *Config, id string, updateStrategy string, rollingUpdatePolicy *computeBeta.InstanceGroupManagerUpdatePolicy, versions []*computeBeta.InstanceGroupManagerVersion, project string, zone string) error {
-	if updateStrategy == "RESTART" || updateStrategy == "REPLACE" {
-		managedInstances, err := config.clientComputeBeta.InstanceGroupManagers.ListManagedInstances(project, zone, id).Do()
-		if err != nil {
-			return fmt.Errorf("Error getting instance group managers instances: %s", err)
-		}
-
-		managedInstanceCount := len(managedInstances.ManagedInstances)
-		instances := make([]string, managedInstanceCount)
-		for i, v := range managedInstances.ManagedInstances {
-			instances[i] = v.Instance
-		}
-
-		recreateInstances := &computeBeta.InstanceGroupManagersRecreateInstancesRequest{
-			Instances: instances,
-		}
-
-		op, err := config.clientComputeBeta.InstanceGroupManagers.RecreateInstances(project, zone, id, recreateInstances).Do()
-		if err != nil {
-			return fmt.Errorf("Error restarting instance group managers instances: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, managedInstanceCount*4, "Restarting InstanceGroupManagers instances")
-		if err != nil {
-			return err
-		}
-	}
-
-	if updateStrategy == "ROLLING_UPDATE" {
-		// UpdatePolicy is set for InstanceGroupManager on update only, because it is only relevant for `Patch` calls.
-		// Other tools(gcloud and UI) capable of executing the same `ROLLING UPDATE` call
-		// expect those values to be provided by user as part of the call
-		// or provide their own defaults without respecting what was previously set on UpdateManager.
-		// To follow the same logic, we provide policy values on relevant update change only.
-		manager := &computeBeta.InstanceGroupManager{
-			UpdatePolicy: rollingUpdatePolicy,
-			Versions:     versions,
-		}
-
-		op, err := config.clientComputeBeta.InstanceGroupManagers.Patch(project, zone, id, manager).Do()
-		if err != nil {
-			return fmt.Errorf("Error updating managed group instances: %s", err)
-		}
-
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating managed group instances")
 		if err != nil {
 			return err
 		}
@@ -538,43 +447,50 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	d.Partial(true)
+	updatedManager := &computeBeta.InstanceGroupManager{
+		Fingerprint: d.Get("fingerprint").(string),
+	}
+	var change bool
 
-	if _, ok := d.GetOk("rolling_update_policy"); d.Get("update_strategy") == "ROLLING_UPDATE" && !ok {
-		return fmt.Errorf("[rolling_update_policy] must be set when 'update_strategy' is set to 'ROLLING_UPDATE'")
+	if d.HasChange("target_pools") {
+		updatedManager.TargetPools = convertStringSet(d.Get("target_pools").(*schema.Set))
+		change = true
 	}
 
-	// If target_pools changes then update
-	if d.HasChange("target_pools") {
-		targetPools := convertStringSet(d.Get("target_pools").(*schema.Set))
-
-		// Build the parameter
-		setTargetPools := &computeBeta.InstanceGroupManagersSetTargetPoolsRequest{
-			Fingerprint: d.Get("fingerprint").(string),
-			TargetPools: targetPools,
+	if d.HasChange("auto_healing_policies") {
+		if v, ok := d.GetOk("auto_healing_policies"); ok {
+			updatedManager.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
+			change = true
 		}
+	}
 
-		op, err := config.clientComputeBeta.InstanceGroupManagers.SetTargetPools(
-			project, zone, d.Id(), setTargetPools).Do()
+	if d.HasChange("version") {
+		updatedManager.Versions = expandVersions(d.Get("version").([]interface{}))
+		change = true
+	}
 
+	if d.HasChange("update_policy") {
+		updatedManager.UpdatePolicy = expandUpdatePolicy(d.Get("update_policy").([]interface{}))
+		change = true
+	}
+
+	if change {
+		op, err := config.clientComputeBeta.InstanceGroupManagers.Patch(project, zone, d.Get("name").(string), updatedManager).Do()
 		if err != nil {
-			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
+			return fmt.Errorf("Error updating managed group instances: %s", err)
 		}
 
-		// Wait for the operation to complete
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating InstanceGroupManager")
+		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating managed group instances")
 		if err != nil {
 			return err
 		}
-
-		d.SetPartial("target_pools")
 	}
 
-	// If named_port changes then update:
+	// named ports can't be updated through PATCH
 	if d.HasChange("named_port") {
 
 		// Build the parameters for a "SetNamedPorts" request:
-		namedPorts := getNamedPortsBeta(d.Get("named_port").([]interface{}))
+		namedPorts := getNamedPortsBeta(d.Get("named_port").(*schema.Set).List())
 		setNamedPorts := &computeBeta.InstanceGroupsSetNamedPortsRequest{
 			NamedPorts: namedPorts,
 		}
@@ -592,10 +508,9 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return err
 		}
-
-		d.SetPartial("named_port")
 	}
 
+	// target_size should be updated through resize
 	if d.HasChange("target_size") {
 		targetSize := int64(d.Get("target_size").(int))
 		op, err := config.clientComputeBeta.InstanceGroupManagers.Resize(
@@ -610,72 +525,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return err
 		}
-
-		d.SetPartial("target_size")
 	}
-
-	// We will always be in v0beta inside this conditional
-	if d.HasChange("auto_healing_policies") {
-		setAutoHealingPoliciesRequest := &computeBeta.InstanceGroupManagersSetAutoHealingRequest{}
-		if v, ok := d.GetOk("auto_healing_policies"); ok {
-			setAutoHealingPoliciesRequest.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
-		}
-
-		op, err := config.clientComputeBeta.InstanceGroupManagers.SetAutoHealingPolicies(
-			project, zone, d.Id(), setAutoHealingPoliciesRequest).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error updating AutoHealingPolicies: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating AutoHealingPolicies")
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("auto_healing_policies")
-	}
-
-	// If instance_template changes then update
-	if d.HasChange("instance_template") {
-		// Build the parameter
-		setInstanceTemplate := &computeBeta.InstanceGroupManagersSetInstanceTemplateRequest{
-			InstanceTemplate: d.Get("instance_template").(string),
-		}
-
-		op, err := config.clientComputeBeta.InstanceGroupManagers.SetInstanceTemplate(project, zone, d.Id(), setInstanceTemplate).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating InstanceGroupManager")
-		if err != nil {
-			return err
-		}
-
-		updateStrategy := d.Get("update_strategy").(string)
-		rollingUpdatePolicy := expandUpdatePolicy(d.Get("rolling_update_policy").([]interface{}))
-		err = performZoneUpdate(config, d.Id(), updateStrategy, rollingUpdatePolicy, nil, project, zone)
-		d.SetPartial("instance_template")
-	}
-
-	// If version changes then update
-	if d.HasChange("version") {
-		updateStrategy := d.Get("update_strategy").(string)
-		rollingUpdatePolicy := expandUpdatePolicy(d.Get("rolling_update_policy").([]interface{}))
-		versions := expandVersions(d.Get("version").([]interface{}))
-		err = performZoneUpdate(config, d.Id(), updateStrategy, rollingUpdatePolicy, versions, project, zone)
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("version")
-	}
-
-	d.Partial(false)
 
 	return resourceComputeInstanceGroupManagerRead(d, meta)
 }

--- a/google-beta/resource_compute_instance_group_manager.go
+++ b/google-beta/resource_compute_instance_group_manager.go
@@ -351,44 +351,44 @@ func flattenFixedOrPercent(fixedOrPercent *computeBeta.FixedOrPercent) []map[str
 func getManager(d *schema.ResourceData, meta interface{}) (*computeBeta.InstanceGroupManager, error) {
 	config := meta.(*Config)
 
-	id, err := parseInstanceGroupManagerId(d.Id())
+	zonalID, err := parseInstanceGroupManagerId(d.Id())
 	if err != nil {
 		return nil, err
 	}
-	if id.Project == "" {
+	if zonalID.Project == "" {
 		project, err := getProject(d, config)
 		if err != nil {
 			return nil, err
 		}
-		id.Project = project
+		zonalID.Project = project
 	}
-	if id.Zone == "" {
-		id.Zone, _ = getZone(d, config)
+	if zonalID.Zone == "" {
+		zonalID.Zone, _ = getZone(d, config)
 	}
 
 	getInstanceGroupManager := func(zone string) (interface{}, error) {
-		return config.clientComputeBeta.InstanceGroupManagers.Get(id.Project, zone, id.Name).Do()
+		return config.clientComputeBeta.InstanceGroupManagers.Get(zonalID.Project, zone, zonalID.Name).Do()
 	}
 
 	var manager *computeBeta.InstanceGroupManager
-	if id.Zone != "" {
-		manager, err = config.clientComputeBeta.InstanceGroupManagers.Get(id.Project, id.Zone, id.Name).Do()
-		if err != nil {
-			return nil, handleNotFoundError(err, d, fmt.Sprintf("Instance Group Manager %q", id.Name))
-		}
-	} else {
+	if zonalID.Zone == "" {
 		// If the resource was imported, the only info we have is the ID. Try to find the resource
 		// by searching in the region of the project.
 		region, err := getRegion(d, config)
 		if err != nil {
 			return nil, err
 		}
-		resource, err := getZonalBetaResourceFromRegion(getInstanceGroupManager, region, config.clientComputeBeta, id.Project)
+		resource, err := getZonalBetaResourceFromRegion(getInstanceGroupManager, region, config.clientComputeBeta, zonalID.Project)
 		if err != nil {
 			return nil, err
 		}
 		if resource != nil {
 			manager = resource.(*computeBeta.InstanceGroupManager)
+		}
+	} else {
+		manager, err = config.clientComputeBeta.InstanceGroupManagers.Get(zonalID.Project, zonalID.Zone, zonalID.Name).Do()
+		if err != nil {
+			return nil, handleNotFoundError(err, d, fmt.Sprintf("Instance Group Manager %q", zonalID.Name))
 		}
 	}
 
@@ -492,35 +492,8 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 	}
 
 	if d.HasChange("update_policy") {
-		oldFixed, _ := d.GetChange("update_policy.0.max_surge_fixed")
-		oldPercent, newPercent := d.GetChange("update_policy.0.max_surge_percent")
-		// if we're going from fixed to percent or percent to fixed, we need to use update, not patch
-		// fixed can be set to 0, so to detect percent to fixed, we check if percent was set before and isn't now
-		if (oldFixed.(int) != 0 && newPercent.(int) != 0) || (oldPercent.(int) != 0 && newPercent.(int) == 0) {
-			updatedManager.Name = d.Get("name").(string)
-			updatedManager.Description = d.Get("description").(string)
-			updatedManager.BaseInstanceName = d.Get("base_instance_name").(string)
-			updatedManager.TargetSize = int64(d.Get("target_size").(int))
-			updatedManager.NamedPorts = getNamedPortsBeta(d.Get("named_port").(*schema.Set).List())
-			updatedManager.TargetPools = convertStringSet(d.Get("target_pools").(*schema.Set))
-			if v, ok := d.GetOk("auto_healing_policies"); ok {
-				updatedManager.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
-			}
-			updatedManager.Versions = expandVersions(d.Get("version").([]interface{}))
-			updatedManager.UpdatePolicy = expandUpdatePolicy(d.Get("update_policy").([]interface{}))
-			change = false
-			op, err := config.clientComputeBeta.InstanceGroupManagers.Update(project, zone, d.Get("name").(string), updatedManager).Do()
-			if err != nil {
-				return fmt.Errorf("Error updating managed group instances: %s", err)
-			}
-			err = computeSharedOperationWait(config.clientCompute, op, project, "Updating managed group instances")
-			if err != nil {
-				return err
-			}
-		} else {
-			updatedManager.UpdatePolicy = expandUpdatePolicy(d.Get("update_policy").([]interface{}))
-			change = true
-		}
+		updatedManager.UpdatePolicy = expandUpdatePolicy(d.Get("update_policy").([]interface{}))
+		change = true
 	}
 
 	if change {
@@ -533,47 +506,47 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		if err != nil {
 			return err
 		}
+	}
 
-		// named ports can't be updated through PATCH
-		// so we call the update method on the instance group, instead of the igm
-		if d.HasChange("named_port") {
+	// named ports can't be updated through PATCH
+	// so we call the update method on the instance group, instead of the igm
+	if d.HasChange("named_port") {
 
-			// Build the parameters for a "SetNamedPorts" request:
-			namedPorts := getNamedPortsBeta(d.Get("named_port").(*schema.Set).List())
-			setNamedPorts := &computeBeta.InstanceGroupsSetNamedPortsRequest{
-				NamedPorts: namedPorts,
-			}
-
-			// Make the request:
-			op, err := config.clientComputeBeta.InstanceGroups.SetNamedPorts(
-				project, zone, d.Get("name").(string), setNamedPorts).Do()
-
-			if err != nil {
-				return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
-			}
-
-			// Wait for the operation to complete:
-			err = computeSharedOperationWait(config.clientCompute, op, project, "Updating InstanceGroupManager")
-			if err != nil {
-				return err
-			}
+		// Build the parameters for a "SetNamedPorts" request:
+		namedPorts := getNamedPortsBeta(d.Get("named_port").(*schema.Set).List())
+		setNamedPorts := &computeBeta.InstanceGroupsSetNamedPortsRequest{
+			NamedPorts: namedPorts,
 		}
 
-		// target_size should be updated through resize
-		if d.HasChange("target_size") {
-			targetSize := int64(d.Get("target_size").(int))
-			op, err := config.clientComputeBeta.InstanceGroupManagers.Resize(
-				project, zone, d.Get("name").(string), targetSize).Do()
+		// Make the request:
+		op, err := config.clientComputeBeta.InstanceGroups.SetNamedPorts(
+			project, zone, d.Get("name").(string), setNamedPorts).Do()
 
-			if err != nil {
-				return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
-			}
+		if err != nil {
+			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
+		}
 
-			// Wait for the operation to complete
-			err = computeSharedOperationWait(config.clientCompute, op, project, "Updating InstanceGroupManager")
-			if err != nil {
-				return err
-			}
+		// Wait for the operation to complete:
+		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating InstanceGroupManager")
+		if err != nil {
+			return err
+		}
+	}
+
+	// target_size should be updated through resize
+	if d.HasChange("target_size") {
+		targetSize := int64(d.Get("target_size").(int))
+		op, err := config.clientComputeBeta.InstanceGroupManagers.Resize(
+			project, zone, d.Get("name").(string), targetSize).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error updating InstanceGroupManager: %s", err)
+		}
+
+		// Wait for the operation to complete
+		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating InstanceGroupManager")
+		if err != nil {
+			return err
 		}
 	}
 
@@ -583,31 +556,31 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	id, err := parseInstanceGroupManagerId(d.Id())
+	zonalID, err := parseInstanceGroupManagerId(d.Id())
 	if err != nil {
 		return err
 	}
 
-	if id.Project == "" {
-		id.Project, err = getProject(d, config)
+	if zonalID.Project == "" {
+		zonalID.Project, err = getProject(d, config)
 		if err != nil {
 			return err
 		}
 	}
 
-	if id.Zone == "" {
-		id.Zone, err = getZone(d, config)
+	if zonalID.Zone == "" {
+		zonalID.Zone, err = getZone(d, config)
 		if err != nil {
 			return err
 		}
 	}
 
-	op, err := config.clientComputeBeta.InstanceGroupManagers.Delete(id.Project, id.Zone, id.Name).Do()
+	op, err := config.clientComputeBeta.InstanceGroupManagers.Delete(zonalID.Project, zonalID.Zone, zonalID.Name).Do()
 	attempt := 0
 	for err != nil && attempt < 20 {
 		attempt++
 		time.Sleep(2000 * time.Millisecond)
-		op, err = config.clientComputeBeta.InstanceGroupManagers.Delete(id.Project, id.Zone, id.Name).Do()
+		op, err = config.clientComputeBeta.InstanceGroupManagers.Delete(zonalID.Project, zonalID.Zone, zonalID.Name).Do()
 	}
 
 	if err != nil {
@@ -617,7 +590,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 	currentSize := int64(d.Get("target_size").(int))
 
 	// Wait for the operation to complete
-	err = computeSharedOperationWait(config.clientCompute, op, id.Project, "Deleting InstanceGroupManager")
+	err = computeSharedOperationWait(config.clientCompute, op, zonalID.Project, "Deleting InstanceGroupManager")
 
 	for err != nil && currentSize > 0 {
 		if !strings.Contains(err.Error(), "timeout") {
@@ -625,7 +598,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 		}
 
 		instanceGroup, err := config.clientComputeBeta.InstanceGroups.Get(
-			id.Project, id.Zone, id.Name).Do()
+			zonalID.Project, zonalID.Zone, zonalID.Name).Do()
 		if err != nil {
 			return fmt.Errorf("Error getting instance group size: %s", err)
 		}
@@ -638,7 +611,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 
 		log.Printf("[INFO] timeout occured, but instance group is shrinking (%d < %d)", instanceGroupSize, currentSize)
 		currentSize = instanceGroupSize
-		err = computeSharedOperationWait(config.clientCompute, op, id.Project, "Deleting InstanceGroupManager")
+		err = computeSharedOperationWait(config.clientCompute, op, zonalID.Project, "Deleting InstanceGroupManager")
 	}
 
 	d.SetId("")
@@ -703,25 +676,29 @@ func expandUpdatePolicy(configured []interface{}) *computeBeta.InstanceGroupMana
 		// when the percent values are set, the fixed values will be ignored
 		if v := data["max_surge_percent"]; v.(int) > 0 {
 			updatePolicy.MaxSurge = &computeBeta.FixedOrPercent{
-				Percent: int64(v.(int)),
+				Percent:    int64(v.(int)),
+				NullFields: []string{"Fixed"},
 			}
 		} else {
 			updatePolicy.MaxSurge = &computeBeta.FixedOrPercent{
 				Fixed: int64(data["max_surge_fixed"].(int)),
 				// allow setting this value to 0
 				ForceSendFields: []string{"Fixed"},
+				NullFields:      []string{"Percent"},
 			}
 		}
 
 		if v := data["max_unavailable_percent"]; v.(int) > 0 {
 			updatePolicy.MaxUnavailable = &computeBeta.FixedOrPercent{
-				Percent: int64(v.(int)),
+				Percent:    int64(v.(int)),
+				NullFields: []string{"Fixed"},
 			}
 		} else {
 			updatePolicy.MaxUnavailable = &computeBeta.FixedOrPercent{
 				Fixed: int64(data["max_unavailable_fixed"].(int)),
 				// allow setting this value to 0
 				ForceSendFields: []string{"Fixed"},
+				NullFields:      []string{"Percent"},
 			}
 		}
 
@@ -753,14 +730,14 @@ func flattenUpdatePolicy(updatePolicy *computeBeta.InstanceGroupManagerUpdatePol
 			up["max_surge_fixed"] = updatePolicy.MaxSurge.Fixed
 			up["max_surge_percent"] = updatePolicy.MaxSurge.Percent
 		} else {
-			up["max_surge_fixed"] = 1
+			up["max_surge_fixed"] = 0
 			up["max_surge_percent"] = 0
 		}
 		if updatePolicy.MaxUnavailable != nil {
 			up["max_unavailable_fixed"] = updatePolicy.MaxUnavailable.Fixed
 			up["max_unavailable_percent"] = updatePolicy.MaxUnavailable.Percent
 		} else {
-			up["max_unavailable_fixed"] = 1
+			up["max_unavailable_fixed"] = 0
 			up["max_unavailable_percent"] = 0
 		}
 		up["min_ready_sec"] = updatePolicy.MinReadySec
@@ -772,42 +749,17 @@ func flattenUpdatePolicy(updatePolicy *computeBeta.InstanceGroupManagerUpdatePol
 }
 
 func resourceInstanceGroupManagerStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	config := meta.(*Config)
 	d.Set("wait_for_instances", false)
-	id, err := parseInstanceGroupManagerId(d.Id())
+	zonalID, err := parseInstanceGroupManagerId(d.Id())
 	if err != nil {
 		return nil, err
 	}
-	if id.Project == "" {
-		project, err := getProject(d, config)
-		if err != nil {
-			return nil, err
-		}
-		id.Project = project
+	if zonalID.Zone == "" || zonalID.Project == "" {
+		return nil, fmt.Errorf("Invalid instance group manager import ID. Expecting {projectId}/{zone}/{name}.")
 	}
-	if id.Zone == "" {
-		id.Zone, _ = getZone(d, config)
-		if id.Zone == "" {
-			region, err := getRegion(d, config)
-			if err != nil {
-				return nil, err
-			}
-
-			getInstanceGroupManager := func(zone string) (interface{}, error) {
-				return config.clientComputeBeta.InstanceGroupManagers.Get(id.Project, zone, id.Name).Do()
-			}
-			mgr, err := getZonalBetaResourceFromRegion(getInstanceGroupManager, region, config.clientComputeBeta, id.Project)
-			if err != nil {
-				return nil, err
-			}
-			if mgr != nil {
-				id.Zone = mgr.(*computeBeta.InstanceGroupManager).Zone
-			}
-		}
-	}
-	d.Set("project", id.Project)
-	d.Set("zone", id.Zone)
-	d.Set("name", id.Name)
+	d.Set("project", zonalID.Project)
+	d.Set("zone", zonalID.Zone)
+	d.Set("name", zonalID.Name)
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/google-beta/resource_compute_instance_group_manager_test.go
+++ b/google-beta/resource_compute_instance_group_manager_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	computeBeta "google.golang.org/api/compute/v0.beta"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -13,8 +11,6 @@ import (
 
 func TestAccInstanceGroupManager_basic(t *testing.T) {
 	t.Parallel()
-
-	var manager computeBeta.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -28,12 +24,6 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_basic(template, target, igm1, igm2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-basic", &manager),
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-no-tp", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-basic",
@@ -52,8 +42,6 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	templateName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igmName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
@@ -64,10 +52,6 @@ func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_targetSizeZero(templateName, igmName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-basic", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-basic",
@@ -80,8 +64,6 @@ func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 
 func TestAccInstanceGroupManager_update(t *testing.T) {
 	t.Parallel()
-
-	var manager computeBeta.InstanceGroupManager
 
 	template1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -96,10 +78,6 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_update(template1, target1, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-update", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-update",
@@ -108,10 +86,6 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceGroupManager_update2(template1, target1, target2, template2, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-update", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-update",
@@ -125,8 +99,6 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	tag1 := "tag1"
 	tag2 := "tag2"
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -138,10 +110,6 @@ func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_updateLifecycle(tag1, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-update", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-update",
@@ -150,10 +118,6 @@ func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceGroupManager_updateLifecycle(tag2, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-update", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-update",
@@ -167,8 +131,6 @@ func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -178,10 +140,6 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_rollingUpdatePolicy(igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-rolling-update-policy",
@@ -190,10 +148,6 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceGroupManager_rollingUpdatePolicy2(igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-rolling-update-policy",
@@ -202,10 +156,6 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceGroupManager_rollingUpdatePolicy3(igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-rolling-update-policy",
@@ -214,10 +164,6 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 			},
 			{
 				Config: testAccInstanceGroupManager_rollingUpdatePolicy4(igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-rolling-update-policy",
@@ -231,8 +177,6 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
@@ -243,12 +187,6 @@ func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_separateRegions(igm1, igm2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-basic", &manager),
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-basic-2", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-basic",
@@ -267,8 +205,6 @@ func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 func TestAccInstanceGroupManager_versions(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	primaryTemplate := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	canaryTemplate := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -280,9 +216,6 @@ func TestAccInstanceGroupManager_versions(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_versions(primaryTemplate, canaryTemplate, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists("google_compute_instance_group_manager.igm-basic", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-basic",
@@ -296,8 +229,6 @@ func TestAccInstanceGroupManager_versions(t *testing.T) {
 func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -310,10 +241,6 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_autoHealingPolicies(template, target, igm, hck),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-basic", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-basic",
@@ -331,8 +258,6 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 func TestAccInstanceGroupManager_selfLinkStability(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -346,8 +271,6 @@ func TestAccInstanceGroupManager_selfLinkStability(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccInstanceGroupManager_selfLinkStability(template, target, igm, hck, autoscaler),
-				Check: testAccCheckInstanceGroupManagerExists(
-					"google_compute_instance_group_manager.igm-basic", &manager),
 			},
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-basic",
@@ -383,48 +306,6 @@ func testAccCheckInstanceGroupManagerDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckInstanceGroupManagerExists(n string, manager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		id, err := parseInstanceGroupManagerId(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		if id.Zone == "" {
-			id.Zone = rs.Primary.Attributes["zone"]
-		}
-
-		if id.Project == "" {
-			id.Project = config.Project
-		}
-
-		found, err := config.clientComputeBeta.InstanceGroupManagers.Get(
-			id.Project, id.Zone, id.Name).Do()
-		if err != nil {
-			return err
-		}
-
-		if found.Name != id.Name {
-			return fmt.Errorf("InstanceGroupManager not found")
-		}
-
-		*manager = *found
-
-		return nil
-	}
 }
 
 func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) string {

--- a/google-beta/resource_compute_instance_group_manager_test.go
+++ b/google-beta/resource_compute_instance_group_manager_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	computeBeta "google.golang.org/api/compute/v0.beta"
-	"google.golang.org/api/compute/v1"
 
 	"sort"
 
@@ -20,7 +19,7 @@ import (
 func TestAccInstanceGroupManager_basic(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -58,7 +57,7 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	templateName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igmName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -86,7 +85,7 @@ func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 func TestAccInstanceGroupManager_update(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	template1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -132,7 +131,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	tag1 := "tag1"
 	tag2 := "tag2"
@@ -163,30 +162,6 @@ func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 	})
 }
 
-func TestAccInstanceGroupManager_updateStrategy(t *testing.T) {
-	t.Parallel()
-
-	var manager compute.InstanceGroupManager
-	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccInstanceGroupManager_updateStrategy(igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerExists(
-						"google_compute_instance_group_manager.igm-update-strategy", &manager),
-					testAccCheckInstanceGroupManagerUpdateStrategy(
-						"google_compute_instance_group_manager.igm-update-strategy", "NONE"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 	t.Parallel()
 
@@ -202,40 +177,36 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 			resource.TestStep{
 				Config: testAccInstanceGroupManager_rollingUpdatePolicy(igm),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerBetaExists(
+					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-rolling-update-policy", &manager),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_strategy", "ROLLING_UPDATE"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.type", "PROACTIVE"),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.type", "PROACTIVE"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.minimal_action", "REPLACE"),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.minimal_action", "REPLACE"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_surge_percent", "50"),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.max_surge_percent", "50"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_unavailable_percent", "50"),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.max_unavailable_percent", "50"),
-					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.min_ready_sec", "20"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.min_ready_sec", "20"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccInstanceGroupManager_rollingUpdatePolicy2(igm),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerBetaExists(
+					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-rolling-update-policy", &manager),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_strategy", "ROLLING_UPDATE"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.type", "PROACTIVE"),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.type", "PROACTIVE"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.minimal_action", "REPLACE"),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.minimal_action", "REPLACE"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_surge_fixed", "2"),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.max_surge_fixed", "2"),
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_unavailable_fixed", "2"),
 					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.max_unavailable_fixed", "2"),
-					resource.TestCheckResourceAttr(
-						"google_compute_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.min_ready_sec", "20"),
-					testAccCheckInstanceGroupManagerRollingUpdatePolicy(
+						"google_compute_instance_group_manager.igm-rolling-update-policy", "update_policy.0.min_ready_sec", "20"),
+					testAccCheckInstanceGroupManagerUpdatePolicy(
 						&manager, "google_compute_instance_group_manager.igm-rolling-update-policy"),
 				),
 			},
@@ -246,7 +217,7 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -286,7 +257,7 @@ func TestAccInstanceGroupManager_versions(t *testing.T) {
 			resource.TestStep{
 				Config: testAccInstanceGroupManager_versions(primaryTemplate, canaryTemplate, igm),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerBetaExists("google_compute_instance_group_manager.igm-basic", &manager),
+					testAccCheckInstanceGroupManagerExists("google_compute_instance_group_manager.igm-basic", &manager),
 					testAccCheckInstanceGroupManagerVersions("google_compute_instance_group_manager.igm-basic", primaryTemplate, canaryTemplate),
 				),
 			},
@@ -317,7 +288,7 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 			resource.TestStep{
 				Config: testAccInstanceGroupManager_autoHealingPolicies(template, target, igm, hck),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInstanceGroupManagerBetaExists(
+					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-basic", &manager),
 					testAccCheckInstanceGroupManagerAutoHealingPolicies("google_compute_instance_group_manager.igm-basic", hck, 10),
 				),
@@ -353,7 +324,7 @@ func TestAccInstanceGroupManager_selfLinkStability(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccInstanceGroupManager_selfLinkStability(template, target, igm, hck, autoscaler),
-				Check: testAccCheckInstanceGroupManagerBetaExists(
+				Check: testAccCheckInstanceGroupManagerExists(
 					"google_compute_instance_group_manager.igm-basic", &manager),
 			},
 		},
@@ -377,36 +348,7 @@ func testAccCheckInstanceGroupManagerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckInstanceGroupManagerExists(n string, manager *compute.InstanceGroupManager) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		found, err := config.clientCompute.InstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if found.Name != rs.Primary.ID {
-			return fmt.Errorf("InstanceGroupManager not found")
-		}
-
-		*manager = *found
-
-		return nil
-	}
-}
-
-func testAccCheckInstanceGroupManagerBetaExists(n string, manager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
+func testAccCheckInstanceGroupManagerExists(n string, manager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -486,7 +428,7 @@ func testAccCheckInstanceGroupManagerUpdated(n string, size int64, targetPools [
 	}
 }
 
-func testAccCheckInstanceGroupManagerNamedPorts(n string, np map[string]int64, instanceGroupManager *compute.InstanceGroupManager) resource.TestCheckFunc {
+func testAccCheckInstanceGroupManagerNamedPorts(n string, np map[string]int64, instanceGroupManager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -627,62 +569,43 @@ func testAccCheckInstanceGroupManagerTemplateTags(n string, tags []string) resou
 	}
 }
 
-func testAccCheckInstanceGroupManagerUpdateStrategy(n, strategy string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		if rs.Primary.Attributes["update_strategy"] != strategy {
-			return fmt.Errorf("Expected strategy to be %s, got %s",
-				strategy, rs.Primary.Attributes["update_strategy"])
-		}
-		return nil
-	}
-}
-
-func testAccCheckInstanceGroupManagerRollingUpdatePolicy(manager *computeBeta.InstanceGroupManager, resource string) resource.TestCheckFunc {
+func testAccCheckInstanceGroupManagerUpdatePolicy(manager *computeBeta.InstanceGroupManager, resource string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs := s.RootModule().Resources[resource]
 
 		updatePolicy := manager.UpdatePolicy
 
-		surgeFixed, _ := strconv.ParseInt(rs.Primary.Attributes["rolling_update_policy.0.max_surge_fixed"], 10, 64)
+		surgeFixed, _ := strconv.ParseInt(rs.Primary.Attributes["update_policy.0.max_surge_fixed"], 10, 64)
 		if updatePolicy.MaxSurge.Fixed != surgeFixed {
 			return fmt.Errorf("Expected update policy MaxSurge to be %d, got %d", surgeFixed, updatePolicy.MaxSurge.Fixed)
 		}
 
-		surgePercent, _ := strconv.ParseInt(rs.Primary.Attributes["rolling_update_policy.0.max_surge_percent"], 10, 64)
+		surgePercent, _ := strconv.ParseInt(rs.Primary.Attributes["update_policy.0.max_surge_percent"], 10, 64)
 		if updatePolicy.MaxSurge.Percent != surgePercent {
 			return fmt.Errorf("Expected update policy MaxSurge to be %d, got %d", surgePercent, updatePolicy.MaxSurge.Percent)
 		}
 
-		unavailableFixed, _ := strconv.ParseInt(rs.Primary.Attributes["rolling_update_policy.0.max_unavailable_fixed"], 10, 64)
+		unavailableFixed, _ := strconv.ParseInt(rs.Primary.Attributes["update_policy.0.max_unavailable_fixed"], 10, 64)
 		if updatePolicy.MaxUnavailable.Fixed != unavailableFixed {
 			return fmt.Errorf("Expected update policy MaxUnavailable to be %d, got %d", unavailableFixed, updatePolicy.MaxUnavailable.Fixed)
 		}
 
-		unavailablePercent, _ := strconv.ParseInt(rs.Primary.Attributes["rolling_update_policy.0.max_unavailable_percent"], 10, 64)
+		unavailablePercent, _ := strconv.ParseInt(rs.Primary.Attributes["update_policy.0.max_unavailable_percent"], 10, 64)
 		if updatePolicy.MaxUnavailable.Percent != unavailablePercent {
 			return fmt.Errorf("Expected update policy MaxUnavailable to be %d, got %d", unavailablePercent, updatePolicy.MaxUnavailable.Percent)
 		}
 
-		policyType := rs.Primary.Attributes["rolling_update_policy.0.type"]
+		policyType := rs.Primary.Attributes["update_policy.0.type"]
 		if updatePolicy.Type != policyType {
 			return fmt.Errorf("Expected  update policy Type to be  \"%s\", got \"%s\"", policyType, updatePolicy.Type)
 		}
 
-		policyAction := rs.Primary.Attributes["rolling_update_policy.0.minimal_action"]
+		policyAction := rs.Primary.Attributes["update_policy.0.minimal_action"]
 		if updatePolicy.MinimalAction != policyAction {
 			return fmt.Errorf("Expected  update policy MinimalAction to be  \"%s\", got \"%s\"", policyAction, updatePolicy.MinimalAction)
 		}
 
-		minReadySec, _ := strconv.ParseInt(rs.Primary.Attributes["rolling_update_policy.0.min_ready_sec"], 10, 64)
+		minReadySec, _ := strconv.ParseInt(rs.Primary.Attributes["update_policy.0.min_ready_sec"], 10, 64)
 		if updatePolicy.MinReadySec != minReadySec {
 			return fmt.Errorf("Expected update policy MinReadySec to be %d, got %d", minReadySec, updatePolicy.MinReadySec)
 		}
@@ -731,7 +654,10 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 	resource "google_compute_instance_group_manager" "igm-basic" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			name = "prod"
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		}
 		target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
 		base_instance_name = "igm-basic"
 		zone = "us-central1-c"
@@ -741,7 +667,10 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 	resource "google_compute_instance_group_manager" "igm-no-tp" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			name = "prod"
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		}
 		base_instance_name = "igm-no-tp"
 		zone = "us-central1-c"
 		target_size = 2
@@ -784,7 +713,10 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 	resource "google_compute_instance_group_manager" "igm-basic" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			name = "prod"
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		}
 		base_instance_name = "igm-basic"
 		zone = "us-central1-c"
 	}
@@ -832,7 +764,10 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 	resource "google_compute_instance_group_manager" "igm-update" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-update.self_link}"
+		version {
+			name = "prod"
+			instance_template = "${google_compute_instance_template.igm-update.self_link}"
+		}
 		target_pools = ["${google_compute_target_pool.igm-update.self_link}"]
 		base_instance_name = "igm-update"
 		zone = "us-central1-c"
@@ -917,7 +852,10 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 	resource "google_compute_instance_group_manager" "igm-update" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-update2.self_link}"
+		version {
+			name = "prod"
+			instance_template = "${google_compute_instance_template.igm-update2.self_link}"
+		}
 		target_pools = [
 			"${google_compute_target_pool.igm-update.self_link}",
 			"${google_compute_target_pool.igm-update2.self_link}",
@@ -970,7 +908,10 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	resource "google_compute_instance_group_manager" "igm-update" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-update.self_link}"
+		version {
+			name = "prod"
+			instance_template = "${google_compute_instance_template.igm-update.self_link}"
+		}
 		base_instance_name = "igm-update"
 		zone = "us-central1-c"
 		target_size = 2
@@ -979,52 +920,6 @@ func testAccInstanceGroupManager_updateLifecycle(tag, igm string) string {
 			port = 8080
 		}
 	}`, tag, igm)
-}
-
-func testAccInstanceGroupManager_updateStrategy(igm string) string {
-	return fmt.Sprintf(`
-	data "google_compute_image" "my_image" {
-		family  = "debian-9"
-		project = "debian-cloud"
-	}
-
-	resource "google_compute_instance_template" "igm-update-strategy" {
-		machine_type = "n1-standard-1"
-		can_ip_forward = false
-		tags = ["terraform-testing"]
-
-		disk {
-			source_image = "${data.google_compute_image.my_image.self_link}"
-			auto_delete = true
-			boot = true
-		}
-
-		network_interface {
-			network = "default"
-		}
-
-		service_account {
-			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-		}
-
-		lifecycle {
-			create_before_destroy = true
-		}
-	}
-
-	resource "google_compute_instance_group_manager" "igm-update-strategy" {
-		description = "Terraform test instance group manager"
-		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-update-strategy.self_link}"
-		base_instance_name = "igm-update-strategy"
-		zone = "us-central1-c"
-		target_size = 2
-		update_strategy = "NONE"
-		named_port {
-			name = "customhttp"
-			port = 8080
-		}
-	}`, igm)
 }
 
 func testAccInstanceGroupManager_rollingUpdatePolicy(igm string) string {
@@ -1061,12 +956,14 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-	instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
+	version {
+		name = "prod"
+		instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
+	}
 	base_instance_name = "igm-rolling-update-policy"
 	zone = "us-central1-c"
 	target_size = 3
-	update_strategy = "ROLLING_UPDATE"
-	rolling_update_policy {
+	update_policy {
 		type = "PROACTIVE"
 		minimal_action = "REPLACE"
 		max_surge_percent = 50
@@ -1110,12 +1007,14 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-	instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
+	version {
+		name = "prod2"
+		instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
+	}
 	base_instance_name = "igm-rolling-update-policy"
 	zone = "us-central1-c"
 	target_size = 3
-	update_strategy = "ROLLING_UPDATE"
-	rolling_update_policy {
+	update_policy {
 		type = "PROACTIVE"
 		minimal_action = "REPLACE"
 		max_surge_fixed = 2
@@ -1163,7 +1062,10 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	resource "google_compute_instance_group_manager" "igm-basic" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+			name = "prod"
+		}
 		base_instance_name = "igm-basic"
 		zone = "us-central1-c"
 		target_size = 2
@@ -1172,7 +1074,10 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	resource "google_compute_instance_group_manager" "igm-basic-2" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			name = "prod"
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		}
 		base_instance_name = "igm-basic-2"
 		zone = "us-west1-b"
 		target_size = 2
@@ -1217,7 +1122,10 @@ resource "google_compute_target_pool" "igm-basic" {
 resource "google_compute_instance_group_manager" "igm-basic" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+	version {
+		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		name = "prod"
+	}
 	target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
 	base_instance_name = "igm-basic"
 	zone = "us-central1-c"
@@ -1350,7 +1258,10 @@ resource "google_compute_target_pool" "igm-basic" {
 resource "google_compute_instance_group_manager" "igm-basic" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+	version {
+		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		name = "primary"
+	}
 	target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
 	base_instance_name = "igm-basic"
 	zone = "us-central1-c"

--- a/google-beta/resource_compute_region_instance_group_manager.go
+++ b/google-beta/resource_compute_region_instance_group_manager.go
@@ -43,10 +43,8 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			},
 
 			"version": &schema.Schema{
-				Type:       schema.TypeList,
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+				Type:     schema.TypeList,
+				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
@@ -112,7 +110,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			},
 
 			"named_port": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -139,13 +137,6 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
-			},
-
-			"update_strategy": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      "NONE",
-				ValidateFunc: validation.StringInSlice([]string{"NONE", "ROLLING_UPDATE"}, false),
 			},
 
 			"target_pools": &schema.Schema{
@@ -205,11 +196,10 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 				},
 			},
 
-			"rolling_update_policy": &schema.Schema{
-				Type:       schema.TypeList,
-				Optional:   true,
-				MaxItems:   1,
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+			"update_policy": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"minimal_action": &schema.Schema{
@@ -228,13 +218,13 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							Default:       0,
-							ConflictsWith: []string{"rolling_update_policy.0.max_surge_percent"},
+							ConflictsWith: []string{"update_policy.0.max_surge_percent"},
 						},
 
 						"max_surge_percent": &schema.Schema{
 							Type:          schema.TypeInt,
 							Optional:      true,
-							ConflictsWith: []string{"rolling_update_policy.0.max_surge_fixed"},
+							ConflictsWith: []string{"update_policy.0.max_surge_fixed"},
 							ValidateFunc:  validation.IntBetween(0, 100),
 						},
 
@@ -242,13 +232,13 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 							Default:       0,
-							ConflictsWith: []string{"rolling_update_policy.0.max_unavailable_percent"},
+							ConflictsWith: []string{"update_policy.0.max_unavailable_percent"},
 						},
 
 						"max_unavailable_percent": &schema.Schema{
 							Type:          schema.TypeInt,
 							Optional:      true,
-							ConflictsWith: []string{"rolling_update_policy.0.max_unavailable_fixed"},
+							ConflictsWith: []string{"update_policy.0.max_unavailable_fixed"},
 							ValidateFunc:  validation.IntBetween(0, 100),
 						},
 
@@ -272,20 +262,16 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 		return err
 	}
 
-	if _, ok := d.GetOk("rolling_update_policy"); d.Get("update_strategy") == "ROLLING_UPDATE" && !ok {
-		return fmt.Errorf("[rolling_update_policy] must be set when 'update_strategy' is set to 'ROLLING_UPDATE'")
-	}
-
 	manager := &computeBeta.InstanceGroupManager{
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
 		BaseInstanceName:    d.Get("base_instance_name").(string),
-		InstanceTemplate:    d.Get("instance_template").(string),
 		TargetSize:          int64(d.Get("target_size").(int)),
-		NamedPorts:          getNamedPortsBeta(d.Get("named_port").([]interface{})),
+		NamedPorts:          getNamedPortsBeta(d.Get("named_port").(*schema.Set).List()),
 		TargetPools:         convertStringSet(d.Get("target_pools").(*schema.Set)),
 		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
 		Versions:            expandVersions(d.Get("version").([]interface{})),
+		UpdatePolicy:        expandUpdatePolicy(d.Get("update_policy").([]interface{})),
 		DistributionPolicy:  expandDistributionPolicy(d.Get("distribution_policy_zones").(*schema.Set)),
 		// Force send TargetSize to allow size of 0.
 		ForceSendFields: []string{"TargetSize"},
@@ -358,7 +344,6 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	}
 
 	d.Set("base_instance_name", manager.BaseInstanceName)
-	d.Set("instance_template", manager.InstanceTemplate)
 	if err := d.Set("version", flattenVersions(manager.Versions)); err != nil {
 		return err
 	}
@@ -376,11 +361,6 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 		return err
 	}
 	d.Set("self_link", ConvertSelfLinkToV1(manager.SelfLink))
-	update_strategy, ok := d.GetOk("update_strategy")
-	if !ok {
-		update_strategy = "NONE"
-	}
-	d.Set("update_strategy", update_strategy.(string))
 
 	if d.Get("wait_for_instances").(bool) {
 		conf := resource.StateChangeConf{
@@ -398,63 +378,6 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	return nil
 }
 
-// Updates an instance group manager by applying the update strategy (REPLACE, RESTART)
-// and rolling update policy (PROACTIVE, OPPORTUNISTIC). Updates performed by API
-// are OPPORTUNISTIC by default.
-func performRegionUpdate(config *Config, id string, updateStrategy string, rollingUpdatePolicy *computeBeta.InstanceGroupManagerUpdatePolicy, versions []*computeBeta.InstanceGroupManagerVersion, project string, region string) error {
-	if updateStrategy == "RESTART" {
-		managedInstances, err := config.clientComputeBeta.RegionInstanceGroupManagers.ListManagedInstances(project, region, id).Do()
-		if err != nil {
-			return fmt.Errorf("Error getting region instance group managers instances: %s", err)
-		}
-
-		managedInstanceCount := len(managedInstances.ManagedInstances)
-		instances := make([]string, managedInstanceCount)
-		for i, v := range managedInstances.ManagedInstances {
-			instances[i] = v.Instance
-		}
-
-		recreateInstances := &computeBeta.RegionInstanceGroupManagersRecreateRequest{
-			Instances: instances,
-		}
-
-		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.RecreateInstances(project, region, id, recreateInstances).Do()
-		if err != nil {
-			return fmt.Errorf("Error restarting region instance group managers instances: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, managedInstanceCount*4, "Restarting RegionInstanceGroupManagers instances")
-		if err != nil {
-			return err
-		}
-	}
-
-	if updateStrategy == "ROLLING_UPDATE" {
-		// UpdatePolicy is set for InstanceGroupManager on update only, because it is only relevant for `Patch` calls.
-		// Other tools(gcloud and UI) capable of executing the same `ROLLING UPDATE` call
-		// expect those values to be provided by user as part of the call
-		// or provide their own defaults without respecting what was previously set on UpdateManager.
-		// To follow the same logic, we provide policy values on relevant update change only.
-		manager := &computeBeta.InstanceGroupManager{
-			UpdatePolicy: rollingUpdatePolicy,
-			Versions:     versions,
-		}
-
-		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.Patch(project, region, id, manager).Do()
-		if err != nil {
-			return fmt.Errorf("Error updating region managed group instances: %s", err)
-		}
-
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating region managed group instances")
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
@@ -463,142 +386,85 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		return err
 	}
 
-	region := d.Get("region").(string)
-
-	d.Partial(true)
-
-	if _, ok := d.GetOk("rolling_update_policy"); d.Get("update_strategy") == "ROLLING_UPDATE" && !ok {
-		return fmt.Errorf("[rolling_update_policy] must be set when 'update_strategy' is set to 'ROLLING_UPDATE'")
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
 	}
+
+	updatedManager := &computeBeta.InstanceGroupManager{
+		Fingerprint: d.Get("fingerprint").(string),
+	}
+	var change bool
 
 	if d.HasChange("target_pools") {
-		targetPools := convertStringSet(d.Get("target_pools").(*schema.Set))
-
-		// Build the parameter
-		setTargetPools := &computeBeta.RegionInstanceGroupManagersSetTargetPoolsRequest{
-			Fingerprint: d.Get("fingerprint").(string),
-			TargetPools: targetPools,
-		}
-
-		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.SetTargetPools(
-			project, region, d.Id(), setTargetPools).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error updating RegionInstanceGroupManager: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating RegionInstanceGroupManager")
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("target_pools")
+		updatedManager.TargetPools = convertStringSet(d.Get("target_pools").(*schema.Set))
+		change = true
 	}
 
-	if d.HasChange("instance_template") {
-		// Build the parameter
-		setInstanceTemplate := &computeBeta.RegionInstanceGroupManagersSetTemplateRequest{
-			InstanceTemplate: d.Get("instance_template").(string),
+	if d.HasChange("auto_healing_policies") {
+		if v, ok := d.GetOk("auto_healing_policies"); ok {
+			updatedManager.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
+			change = true
 		}
-
-		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.SetInstanceTemplate(
-			project, region, d.Id(), setInstanceTemplate).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error updating RegionInstanceGroupManager: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating InstanceGroupManager")
-		if err != nil {
-			return err
-		}
-
-		updateStrategy := d.Get("update_strategy").(string)
-		rollingUpdatePolicy := expandUpdatePolicy(d.Get("rolling_update_policy").([]interface{}))
-		err = performRegionUpdate(config, d.Id(), updateStrategy, rollingUpdatePolicy, nil, project, region)
-		d.SetPartial("instance_template")
 	}
 
-	// If version changes then update
 	if d.HasChange("version") {
-		updateStrategy := d.Get("update_strategy").(string)
-		rollingUpdatePolicy := expandUpdatePolicy(d.Get("rolling_update_policy").([]interface{}))
-		versions := expandVersions(d.Get("version").([]interface{}))
-		err = performRegionUpdate(config, d.Id(), updateStrategy, rollingUpdatePolicy, versions, project, region)
+		updatedManager.Versions = expandVersions(d.Get("version").([]interface{}))
+		change = true
+	}
+
+	if d.HasChange("update_policy") {
+		updatedManager.UpdatePolicy = expandUpdatePolicy(d.Get("update_policy").([]interface{}))
+		change = true
+	}
+
+	if change {
+		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.Patch(project, region, d.Get("name").(string), updatedManager).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating region managed group instances: %s", err)
+		}
+
+		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating managed group instances")
 		if err != nil {
 			return err
 		}
-
-		d.SetPartial("version")
 	}
 
+	// named ports can't be updated through PATCH
 	if d.HasChange("named_port") {
-		// Build the parameters for a "SetNamedPorts" request:
-		namedPorts := getNamedPortsBeta(d.Get("named_port").([]interface{}))
+		namedPorts := getNamedPortsBeta(d.Get("named_port").(*schema.Set).List())
 		setNamedPorts := &computeBeta.RegionInstanceGroupsSetNamedPortsRequest{
 			NamedPorts: namedPorts,
 		}
 
-		// Make the request:
 		op, err := config.clientComputeBeta.RegionInstanceGroups.SetNamedPorts(
-			project, region, d.Id(), setNamedPorts).Do()
+			project, region, d.Get("name").(string), setNamedPorts).Do()
 
 		if err != nil {
 			return fmt.Errorf("Error updating RegionInstanceGroupManager: %s", err)
 		}
 
-		// Wait for the operation to complete:
 		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating RegionInstanceGroupManager")
 		if err != nil {
 			return err
 		}
-
-		d.SetPartial("named_port")
 	}
 
+	// target size should use resize
 	if d.HasChange("target_size") {
 		targetSize := int64(d.Get("target_size").(int))
 		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.Resize(
-			project, region, d.Id(), targetSize).Do()
+			project, region, d.Get("name").(string), targetSize).Do()
 
 		if err != nil {
 			return fmt.Errorf("Error resizing RegionInstanceGroupManager: %s", err)
 		}
 
-		// Wait for the operation to complete
 		err = computeSharedOperationWait(config.clientCompute, op, project, "Resizing RegionInstanceGroupManager")
 		if err != nil {
 			return err
 		}
-
-		d.SetPartial("target_size")
 	}
-
-	if d.HasChange("auto_healing_policies") {
-		setAutoHealingPoliciesRequest := &computeBeta.RegionInstanceGroupManagersSetAutoHealingRequest{}
-		if v, ok := d.GetOk("auto_healing_policies"); ok {
-			setAutoHealingPoliciesRequest.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
-		}
-
-		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.SetAutoHealingPolicies(
-			project, region, d.Id(), setAutoHealingPoliciesRequest).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error updating AutoHealingPolicies: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating AutoHealingPolicies")
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("auto_healing_policies")
-	}
-
-	d.Partial(false)
 
 	return resourceComputeRegionInstanceGroupManagerRead(d, meta)
 }
@@ -611,7 +477,10 @@ func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, met
 		return err
 	}
 
-	region := d.Get("region").(string)
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
 
 	op, err := config.clientComputeBeta.RegionInstanceGroupManagers.Delete(project, region, d.Id()).Do()
 

--- a/google-beta/resource_compute_region_instance_group_manager.go
+++ b/google-beta/resource_compute_region_instance_group_manager.go
@@ -437,10 +437,9 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 	}
 
 	if d.HasChange("auto_healing_policies") {
-		if v, ok := d.GetOk("auto_healing_policies"); ok {
-			updatedManager.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
-			change = true
-		}
+		updatedManager.AutoHealingPolicies = expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{}))
+		updatedManager.ForceSendFields = append(updatedManager.ForceSendFields, "AutoHealingPolicies")
+		change = true
 	}
 
 	if d.HasChange("version") {

--- a/google-beta/resource_compute_region_instance_group_manager_test.go
+++ b/google-beta/resource_compute_region_instance_group_manager_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	computeBeta "google.golang.org/api/compute/v0.beta"
-	"google.golang.org/api/compute/v1"
 
 	"sort"
 
@@ -19,7 +18,7 @@ import (
 func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -47,7 +46,7 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	templateName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igmName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -75,7 +74,7 @@ func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	template1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -114,10 +113,9 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				ResourceName:            "google_compute_region_instance_group_manager.igm-update",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"update_strategy"},
+				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -126,7 +124,7 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	tag1 := "tag1"
 	tag2 := "tag2"
@@ -157,31 +155,7 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 	})
 }
 
-func TestAccRegionInstanceGroupManager_updateStrategy(t *testing.T) {
-	t.Parallel()
-
-	var manager compute.InstanceGroupManager
-	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccRegionInstanceGroupManager_updateStrategy(igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-update-strategy", &manager),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-update-strategy", "update_strategy", "NONE"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
+func TestAccRegionInstanceGroupManager_updatePolicy(t *testing.T) {
 	t.Parallel()
 
 	var manager computeBeta.InstanceGroupManager
@@ -194,42 +168,38 @@ func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm),
+				Config: testAccRegionInstanceGroupManager_updatePolicy(igm),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerBetaExists(
+					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-rolling-update-policy", &manager),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_strategy", "ROLLING_UPDATE"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.type", "PROACTIVE"),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.type", "PROACTIVE"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.minimal_action", "REPLACE"),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.minimal_action", "REPLACE"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_surge_fixed", "2"),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.max_surge_fixed", "2"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_unavailable_fixed", "2"),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.max_unavailable_fixed", "2"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.min_ready_sec", "20"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.min_ready_sec", "20"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccRegionInstanceGroupManager_rollingUpdatePolicy2(igm),
+				Config: testAccRegionInstanceGroupManager_updatePolicy2(igm),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerBetaExists(
+					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-rolling-update-policy", &manager),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_strategy", "ROLLING_UPDATE"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.type", "PROACTIVE"),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.type", "PROACTIVE"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.minimal_action", "REPLACE"),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.minimal_action", "REPLACE"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_surge_fixed", "2"),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.max_surge_fixed", "2"),
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_unavailable_fixed", "0"),
 					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.max_unavailable_fixed", "0"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "rolling_update_policy.0.min_ready_sec", "10"),
-					testAccCheckInstanceGroupManagerRollingUpdatePolicy(
+						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.min_ready_sec", "10"),
+					testAccCheckInstanceGroupManagerUpdatePolicy(
 						&manager, "google_compute_region_instance_group_manager.igm-rolling-update-policy"),
 				),
 			},
@@ -240,7 +210,7 @@ func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 	t.Parallel()
 
-	var manager compute.InstanceGroupManager
+	var manager computeBeta.InstanceGroupManager
 
 	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -280,7 +250,7 @@ func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 			resource.TestStep{
 				Config: testAccRegionInstanceGroupManager_versions(primaryTemplate, canaryTemplate, igm),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerBetaExists("google_compute_region_instance_group_manager.igm-basic", &manager),
+					testAccCheckRegionInstanceGroupManagerExists("google_compute_region_instance_group_manager.igm-basic", &manager),
 					testAccCheckRegionInstanceGroupManagerVersions("google_compute_region_instance_group_manager.igm-basic", primaryTemplate, canaryTemplate),
 				),
 			},
@@ -311,7 +281,7 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 			resource.TestStep{
 				Config: testAccRegionInstanceGroupManager_autoHealingPolicies(template, target, igm, hck),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerBetaExists(
+					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-basic", &manager),
 					testAccCheckRegionInstanceGroupManagerAutoHealingPolicies("google_compute_region_instance_group_manager.igm-basic", hck, 10),
 				),
@@ -337,7 +307,7 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 			resource.TestStep{
 				Config: testAccRegionInstanceGroupManager_distributionPolicy(template, igm, zones),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerBetaExists(
+					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-basic", &manager),
 					testAccCheckRegionInstanceGroupManagerDistributionPolicy("google_compute_region_instance_group_manager.igm-basic", zones),
 				),
@@ -363,36 +333,7 @@ func testAccCheckRegionInstanceGroupManagerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckRegionInstanceGroupManagerExists(n string, manager *compute.InstanceGroupManager) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		found, err := config.clientCompute.RegionInstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if found.Name != rs.Primary.ID {
-			return fmt.Errorf("RegionInstanceGroupManager not found")
-		}
-
-		*manager = *found
-
-		return nil
-	}
-}
-
-func testAccCheckRegionInstanceGroupManagerBetaExists(n string, manager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
+func testAccCheckRegionInstanceGroupManagerExists(n string, manager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -472,7 +413,7 @@ func testAccCheckRegionInstanceGroupManagerUpdated(n string, size int64, targetP
 	}
 }
 
-func testAccCheckRegionInstanceGroupManagerNamedPorts(n string, np map[string]int64, instanceGroupManager *compute.InstanceGroupManager) resource.TestCheckFunc {
+func testAccCheckRegionInstanceGroupManagerNamedPorts(n string, np map[string]int64, instanceGroupManager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -699,7 +640,10 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 	resource "google_compute_region_instance_group_manager" "igm-basic" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			name = "primary"
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		}
 		target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
 		base_instance_name = "igm-basic"
 		region = "us-central1"
@@ -709,7 +653,10 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 	resource "google_compute_region_instance_group_manager" "igm-no-tp" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			name = "primary"
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		}
 		base_instance_name = "igm-no-tp"
 		region = "us-central1"
 		target_size = 2
@@ -752,7 +699,10 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 	resource "google_compute_region_instance_group_manager" "igm-basic" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			name = "primary"
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		}
 		base_instance_name = "igm-basic"
 		region = "us-central1"
 	}
@@ -800,7 +750,10 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 	resource "google_compute_region_instance_group_manager" "igm-update" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-update.self_link}"
+		version {
+			name = "primary"
+			instance_template = "${google_compute_instance_template.igm-update.self_link}"
+		}
 		target_pools = ["${google_compute_target_pool.igm-update.self_link}"]
 		base_instance_name = "igm-update"
 		region = "us-central1"
@@ -885,7 +838,10 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 	resource "google_compute_region_instance_group_manager" "igm-update" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-update2.self_link}"
+		version {
+			instance_template = "${google_compute_instance_template.igm-update2.self_link}"
+			name = "primary"
+		}
 		target_pools = [
 			"${google_compute_target_pool.igm-update.self_link}",
 			"${google_compute_target_pool.igm-update2.self_link}",
@@ -938,7 +894,10 @@ func testAccRegionInstanceGroupManager_updateLifecycle(tag, igm string) string {
 	resource "google_compute_region_instance_group_manager" "igm-update" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-update.self_link}"
+		version {
+			instance_template = "${google_compute_instance_template.igm-update.self_link}"
+			name = "primary"
+		}
 		base_instance_name = "igm-update"
 		region = "us-central1"
 		target_size = 2
@@ -983,7 +942,10 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 	resource "google_compute_region_instance_group_manager" "igm-basic" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+			name = "primary"
+		}
 		base_instance_name = "igm-basic"
 		region = "us-central1"
 		target_size = 2
@@ -992,7 +954,10 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 	resource "google_compute_region_instance_group_manager" "igm-basic-2" {
 		description = "Terraform test instance group manager"
 		name = "%s"
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		version {
+			instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+			name = "primary"
+		}
 		base_instance_name = "igm-basic-2"
 		region = "us-west1"
 		target_size = 2
@@ -1037,7 +1002,10 @@ resource "google_compute_target_pool" "igm-basic" {
 resource "google_compute_region_instance_group_manager" "igm-basic" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+	version {
+		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		name = "primary"
+	}
 	target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
 	base_instance_name = "igm-basic"
 	region = "us-central1"
@@ -1156,7 +1124,10 @@ resource "google_compute_instance_template" "igm-basic" {
 resource "google_compute_region_instance_group_manager" "igm-basic" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+	version {
+		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		name = "primary"
+	}
 	base_instance_name = "igm-basic"
 	region = "us-central1"
 	target_size = 2
@@ -1165,53 +1136,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 	`, template, igm, strings.Join(zones, "\",\""))
 }
 
-func testAccRegionInstanceGroupManager_updateStrategy(igm string) string {
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-	family  = "debian-9"
-	project = "debian-cloud"
-}
-
-resource "google_compute_instance_template" "igm-update-strategy" {
-	machine_type   = "n1-standard-1"
-	can_ip_forward = false
-	tags           = ["terraform-testing"]
-
-	disk {
-		source_image = "${data.google_compute_image.my_image.self_link}"
-		auto_delete  = true
-		boot         = true
-	}
-
-	network_interface {
-		network = "default"
-	}
-
-	service_account {
-		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-	}
-
-	lifecycle {
-		create_before_destroy = true
-	}
-}
-
-resource "google_compute_region_instance_group_manager" "igm-update-strategy" {
-	description                = "Terraform test instance group manager"
-	name                       = "%s"
-	instance_template          = "${google_compute_instance_template.igm-update-strategy.self_link}"
-	base_instance_name         = "rigm-update-strategy"
-	region                     = "us-central1"
-	target_size                = 2
-	update_strategy            = "NONE"
-	named_port {
-		name = "customhttp"
-		port = 8080
-	}
-}`, igm)
-}
-
-func testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm string) string {
+func testAccRegionInstanceGroupManager_updatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
 	family  = "debian-9"
@@ -1245,14 +1170,16 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 resource "google_compute_region_instance_group_manager" "igm-rolling-update-policy" {
 	description        = "Terraform test instance group manager"
 	name               = "%s"
-	instance_template  = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
+	version {
+		instance_template  = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
+		name = "primary"
+	}
 	base_instance_name = "igm-rolling-update-policy"
 	region             = "us-central1"
 	target_size        = 4
 	distribution_policy_zones  = ["us-central1-a", "us-central1-f"]
-	update_strategy = "ROLLING_UPDATE"
 
-	rolling_update_policy {
+	update_policy {
 		type                  = "PROACTIVE"
 		minimal_action        = "REPLACE"
 		max_surge_fixed       = 2
@@ -1267,7 +1194,7 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 }`, igm)
 }
 
-func testAccRegionInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
+func testAccRegionInstanceGroupManager_updatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
 	family  = "debian-9"
@@ -1297,14 +1224,16 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 resource "google_compute_region_instance_group_manager" "igm-rolling-update-policy" {
 	description                = "Terraform test instance group manager"
 	name                       = "%s"
-	instance_template          = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
+	version {
+		name              = "primary"
+		instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
+	}
 	base_instance_name         = "igm-rolling-update-policy"
 	region                     = "us-central1"
 	distribution_policy_zones  = ["us-central1-a", "us-central1-f"]
 	target_size                = 3
-	update_strategy            = "ROLLING_UPDATE"
 
-	rolling_update_policy {
+	update_policy {
 		type                  = "PROACTIVE"
 		minimal_action        = "REPLACE"
 		max_surge_fixed       = 2

--- a/google-beta/resource_compute_region_instance_group_manager_test.go
+++ b/google-beta/resource_compute_region_instance_group_manager_test.go
@@ -2,13 +2,10 @@ package google
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 	"testing"
 
 	computeBeta "google.golang.org/api/compute/v0.beta"
-
-	"sort"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -30,7 +27,7 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
@@ -38,6 +35,16 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-no-tp", &manager),
 				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-no-tp",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -56,19 +63,20 @@ func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_targetSizeZero(templateName, igmName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-basic", &manager),
 				),
 			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
-
-	if manager.TargetSize != 0 {
-		t.Errorf("Expected target_size to be 0, got %d", manager.TargetSize)
-	}
 }
 
 func TestAccRegionInstanceGroupManager_update(t *testing.T) {
@@ -87,32 +95,26 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_update(template1, target1, igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-update", &manager),
-					testAccCheckRegionInstanceGroupManagerNamedPorts(
-						"google_compute_region_instance_group_manager.igm-update",
-						map[string]int64{"customhttp": 8080},
-						&manager),
 				),
 			},
-			resource.TestStep{
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccRegionInstanceGroupManager_update2(template1, target1, target2, template2, igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-update", &manager),
-					testAccCheckRegionInstanceGroupManagerUpdated(
-						"google_compute_region_instance_group_manager.igm-update", 3,
-						[]string{target1, target2}, template2),
-					testAccCheckRegionInstanceGroupManagerNamedPorts(
-						"google_compute_region_instance_group_manager.igm-update",
-						map[string]int64{"customhttp": 8080, "customhttps": 8443},
-						&manager),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -135,21 +137,29 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_updateLifecycle(tag1, igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-update", &manager),
 				),
 			},
-			resource.TestStep{
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccRegionInstanceGroupManager_updateLifecycle(tag2, igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-update", &manager),
-					testAccCheckRegionInstanceGroupManagerTemplateTags(
-						"google_compute_region_instance_group_manager.igm-update", []string{tag2}),
 				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -167,41 +177,29 @@ func TestAccRegionInstanceGroupManager_updatePolicy(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_updatePolicy(igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-rolling-update-policy", &manager),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.type", "PROACTIVE"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.minimal_action", "REPLACE"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_surge_fixed", "2"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_unavailable_fixed", "2"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.min_ready_sec", "20"),
 				),
 			},
-			resource.TestStep{
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-rolling-update-policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccRegionInstanceGroupManager_updatePolicy2(igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-rolling-update-policy", &manager),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.type", "PROACTIVE"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.minimal_action", "REPLACE"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_surge_fixed", "2"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.max_unavailable_fixed", "0"),
-					resource.TestCheckResourceAttr(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", "update_policy.0.min_ready_sec", "10"),
-					testAccCheckInstanceGroupManagerUpdatePolicy(
-						&manager, "google_compute_region_instance_group_manager.igm-rolling-update-policy"),
 				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-rolling-update-policy",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -220,7 +218,7 @@ func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_separateRegions(igm1, igm2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
@@ -228,6 +226,16 @@ func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-basic-2", &manager),
 				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-basic-2",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -247,14 +255,13 @@ func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_versions(primaryTemplate, canaryTemplate, igm),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists("google_compute_region_instance_group_manager.igm-basic", &manager),
-					testAccCheckRegionInstanceGroupManagerVersions("google_compute_region_instance_group_manager.igm-basic", primaryTemplate, canaryTemplate),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -278,13 +285,17 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_autoHealingPolicies(template, target, igm, hck),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-basic", &manager),
-					testAccCheckRegionInstanceGroupManagerAutoHealingPolicies("google_compute_region_instance_group_manager.igm-basic", hck, 10),
 				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -304,13 +315,17 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRegionInstanceGroupManager_distributionPolicy(template, igm, zones),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRegionInstanceGroupManagerExists(
 						"google_compute_region_instance_group_manager.igm-basic", &manager),
-					testAccCheckRegionInstanceGroupManagerDistributionPolicy("google_compute_region_instance_group_manager.igm-basic", zones),
 				),
+			},
+			{
+				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -323,8 +338,18 @@ func testAccCheckRegionInstanceGroupManagerDestroy(s *terraform.State) error {
 		if rs.Type != "google_compute_region_instance_group_manager" {
 			continue
 		}
-		_, err := config.clientCompute.RegionInstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
+		id, err := parseRegionInstanceGroupManagerId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if id.Project == "" {
+			id.Project = config.Project
+		}
+		if id.Region == "" {
+			id.Region = rs.Primary.Attributes["region"]
+		}
+		_, err = config.clientCompute.RegionInstanceGroupManagers.Get(
+			id.Project, id.Region, id.Name).Do()
 		if err == nil {
 			return fmt.Errorf("RegionInstanceGroupManager still exists")
 		}
@@ -346,254 +371,28 @@ func testAccCheckRegionInstanceGroupManagerExists(n string, manager *computeBeta
 
 		config := testAccProvider.Meta().(*Config)
 
+		id, err := parseRegionInstanceGroupManagerId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if id.Project == "" {
+			id.Project = config.Project
+		}
+		if id.Region == "" {
+			id.Region = rs.Primary.Attributes["region"]
+		}
+
 		found, err := config.clientComputeBeta.RegionInstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
+			id.Project, id.Region, id.Name).Do()
 		if err != nil {
 			return err
 		}
 
-		if found.Name != rs.Primary.ID {
+		if found.Name != id.Name {
 			return fmt.Errorf("RegionInstanceGroupManager not found")
 		}
 
 		*manager = *found
-
-		return nil
-	}
-}
-
-func testAccCheckRegionInstanceGroupManagerUpdated(n string, size int64, targetPools []string, template string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		manager, err := config.clientCompute.RegionInstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		// Cannot check the target pool as the instance creation is asynchronous.  However, can
-		// check the target_size.
-		if manager.TargetSize != size {
-			return fmt.Errorf("instance count incorrect")
-		}
-
-		tpNames := make([]string, 0, len(manager.TargetPools))
-		for _, targetPool := range manager.TargetPools {
-			tpNames = append(tpNames, GetResourceNameFromSelfLink(targetPool))
-		}
-
-		sort.Strings(tpNames)
-		sort.Strings(targetPools)
-		if !reflect.DeepEqual(tpNames, targetPools) {
-			return fmt.Errorf("target pools incorrect. Expected %s, got %s", targetPools, tpNames)
-		}
-
-		// check that the instance template updated
-		instanceTemplate, err := config.clientCompute.InstanceTemplates.Get(
-			config.Project, template).Do()
-		if err != nil {
-			return fmt.Errorf("Error reading instance template: %s", err)
-		}
-
-		if instanceTemplate.Name != template {
-			return fmt.Errorf("instance template not updated")
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckRegionInstanceGroupManagerNamedPorts(n string, np map[string]int64, instanceGroupManager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		manager, err := config.clientCompute.RegionInstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		var found bool
-		for _, namedPort := range manager.NamedPorts {
-			found = false
-			for name, port := range np {
-				if namedPort.Name == name && namedPort.Port == port {
-					found = true
-				}
-			}
-			if !found {
-				return fmt.Errorf("named port incorrect")
-			}
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckRegionInstanceGroupManagerVersions(n string, primaryTemplate string, canaryTemplate string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		manager, err := config.clientComputeBeta.RegionInstanceGroupManagers.Get(config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if len(manager.Versions) != 2 {
-			return fmt.Errorf("Expected # of versions to be 2, got %d", len(manager.Versions))
-		}
-
-		primaryVersion := manager.Versions[0]
-		if !strings.Contains(primaryVersion.InstanceTemplate, primaryTemplate) {
-			return fmt.Errorf("Expected string \"%s\" to appear in \"%s\"", primaryTemplate, primaryVersion.InstanceTemplate)
-		}
-
-		canaryVersion := manager.Versions[1]
-		if !strings.Contains(canaryVersion.InstanceTemplate, canaryTemplate) {
-			return fmt.Errorf("Expected string \"%s\" to appear in \"%s\"", canaryTemplate, canaryVersion.InstanceTemplate)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckRegionInstanceGroupManagerAutoHealingPolicies(n, hck string, initialDelaySec int64) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		manager, err := config.clientComputeBeta.RegionInstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if len(manager.AutoHealingPolicies) != 1 {
-			return fmt.Errorf("Expected # of auto healing policies to be 1, got %d", len(manager.AutoHealingPolicies))
-		}
-		autoHealingPolicy := manager.AutoHealingPolicies[0]
-
-		if !strings.Contains(autoHealingPolicy.HealthCheck, hck) {
-			return fmt.Errorf("Expected string \"%s\" to appear in \"%s\"", hck, autoHealingPolicy.HealthCheck)
-		}
-
-		if autoHealingPolicy.InitialDelaySec != initialDelaySec {
-			return fmt.Errorf("Expected auto healing policy inital delay to be %d, got %d", initialDelaySec, autoHealingPolicy.InitialDelaySec)
-		}
-		return nil
-	}
-}
-
-func testAccCheckRegionInstanceGroupManagerDistributionPolicy(n string, zones []string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		manager, err := config.clientComputeBeta.RegionInstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		if manager.DistributionPolicy == nil {
-			return fmt.Errorf("Expected distribution policy to exist")
-		}
-
-		zoneConfigs := manager.DistributionPolicy.Zones
-		if len(zoneConfigs) != len(zones) {
-			return fmt.Errorf("Expected number of zones in distribution policy to match; had %d, expected %d", len(zoneConfigs), len(zones))
-		}
-
-		sort.Strings(zones)
-		sortedExisting := make([]string, 0)
-		for _, zone := range zoneConfigs {
-			sortedExisting = append(sortedExisting, zone.Zone)
-		}
-		sort.Strings(sortedExisting)
-
-		for i := 0; i < len(zones); i++ {
-			if !strings.HasSuffix(sortedExisting[i], zones[i]) {
-				return fmt.Errorf("found mismatched zone configuration: expected entry #%d as '%s', got %s", i, zones[i], sortedExisting[i])
-			}
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckRegionInstanceGroupManagerTemplateTags(n string, tags []string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		manager, err := config.clientCompute.RegionInstanceGroupManagers.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err != nil {
-			return err
-		}
-
-		// check that the instance template updated
-		instanceTemplate, err := config.clientCompute.InstanceTemplates.Get(
-			config.Project, GetResourceNameFromSelfLink(manager.InstanceTemplate)).Do()
-		if err != nil {
-			return fmt.Errorf("Error reading instance template: %s", err)
-		}
-
-		if !reflect.DeepEqual(instanceTemplate.Properties.Tags.Items, tags) {
-			return fmt.Errorf("instance template not updated")
-		}
 
 		return nil
 	}

--- a/google-beta/resource_compute_region_instance_group_manager_test.go
+++ b/google-beta/resource_compute_region_instance_group_manager_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	computeBeta "google.golang.org/api/compute/v0.beta"
-
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -14,8 +12,6 @@ import (
 
 func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 	t.Parallel()
-
-	var manager computeBeta.InstanceGroupManager
 
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -29,12 +25,6 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-basic", &manager),
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-no-tp", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
@@ -53,8 +43,6 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	templateName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igmName := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
@@ -65,10 +53,6 @@ func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_targetSizeZero(templateName, igmName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-basic", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
@@ -81,8 +65,6 @@ func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 
 func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 	t.Parallel()
-
-	var manager computeBeta.InstanceGroupManager
 
 	template1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -97,10 +79,6 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_update(template1, target1, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-update", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
@@ -109,10 +87,6 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 			},
 			{
 				Config: testAccRegionInstanceGroupManager_update2(template1, target1, target2, template2, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-update", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
@@ -126,8 +100,6 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	tag1 := "tag1"
 	tag2 := "tag2"
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -139,10 +111,6 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_updateLifecycle(tag1, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-update", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
@@ -151,10 +119,6 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 			},
 			{
 				Config: testAccRegionInstanceGroupManager_updateLifecycle(tag2, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-update", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-update",
@@ -168,8 +132,6 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 func TestAccRegionInstanceGroupManager_updatePolicy(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -179,10 +141,6 @@ func TestAccRegionInstanceGroupManager_updatePolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_updatePolicy(igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-rolling-update-policy",
@@ -191,10 +149,6 @@ func TestAccRegionInstanceGroupManager_updatePolicy(t *testing.T) {
 			},
 			{
 				Config: testAccRegionInstanceGroupManager_updatePolicy2(igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-rolling-update-policy", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-rolling-update-policy",
@@ -208,8 +162,6 @@ func TestAccRegionInstanceGroupManager_updatePolicy(t *testing.T) {
 func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
@@ -220,12 +172,6 @@ func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_separateRegions(igm1, igm2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-basic", &manager),
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-basic-2", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
@@ -244,8 +190,6 @@ func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	primaryTemplate := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	canaryTemplate := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -257,9 +201,6 @@ func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_versions(primaryTemplate, canaryTemplate, igm),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists("google_compute_region_instance_group_manager.igm-basic", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
@@ -273,8 +214,6 @@ func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -287,10 +226,6 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_autoHealingPolicies(template, target, igm, hck),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-basic", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
@@ -304,8 +239,6 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 	t.Parallel()
 
-	var manager computeBeta.InstanceGroupManager
-
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	zones := []string{"us-central1-a", "us-central1-b"}
@@ -317,10 +250,6 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRegionInstanceGroupManager_distributionPolicy(template, igm, zones),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckRegionInstanceGroupManagerExists(
-						"google_compute_region_instance_group_manager.igm-basic", &manager),
-				),
 			},
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-basic",
@@ -356,46 +285,6 @@ func testAccCheckRegionInstanceGroupManagerDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckRegionInstanceGroupManagerExists(n string, manager *computeBeta.InstanceGroupManager) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		id, err := parseRegionInstanceGroupManagerId(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-		if id.Project == "" {
-			id.Project = config.Project
-		}
-		if id.Region == "" {
-			id.Region = rs.Primary.Attributes["region"]
-		}
-
-		found, err := config.clientComputeBeta.RegionInstanceGroupManagers.Get(
-			id.Project, id.Region, id.Name).Do()
-		if err != nil {
-			return err
-		}
-
-		if found.Name != id.Name {
-			return fmt.Errorf("RegionInstanceGroupManager not found")
-		}
-
-		*manager = *found
-
-		return nil
-	}
 }
 
 func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string) string {


### PR DESCRIPTION
Fix (Regional) Instance Group Managers to use the Patch method and fix
the update policy support. Get rid of update strategy, which is no
longer needed.