### PR TITLE
Adding KMS enabled disk encryption

### DIFF
--- a/google-beta/resource_compute_disk.go
+++ b/google-beta/resource_compute_disk.go
@@ -937,7 +937,7 @@ func flattenComputeDiskSourceImageEncryptionKey(v interface{}) interface{} {
 	transformed["sha256"] =
 		flattenComputeDiskSourceImageEncryptionKeySha256(original["sha256"])
 	transformed["kms_key_self_link"] =
-		flattenComputeDiskSourceImageEncryptionKeyKms_key_self_link(original["kmsKeyName"])
+		flattenComputeDiskSourceImageEncryptionKeyKmsKeySelfLink(original["kmsKeyName"])
 	return []interface{}{transformed}
 }
 func flattenComputeDiskSourceImageEncryptionKeyRawKey(v interface{}) interface{} {
@@ -948,7 +948,7 @@ func flattenComputeDiskSourceImageEncryptionKeySha256(v interface{}) interface{}
 	return v
 }
 
-func flattenComputeDiskSourceImageEncryptionKeyKms_key_self_link(v interface{}) interface{} {
+func flattenComputeDiskSourceImageEncryptionKeyKmsKeySelfLink(v interface{}) interface{} {
 	return v
 }
 
@@ -967,7 +967,7 @@ func flattenComputeDiskDiskEncryptionKey(v interface{}) interface{} {
 	transformed["sha256"] =
 		flattenComputeDiskDiskEncryptionKeySha256(original["sha256"])
 	transformed["kms_key_self_link"] =
-		flattenComputeDiskDiskEncryptionKeyKms_key_self_link(original["kmsKeyName"])
+		flattenComputeDiskDiskEncryptionKeyKmsKeySelfLink(original["kmsKeyName"])
 	return []interface{}{transformed}
 }
 func flattenComputeDiskDiskEncryptionKeyRawKey(v interface{}) interface{} {
@@ -978,7 +978,7 @@ func flattenComputeDiskDiskEncryptionKeySha256(v interface{}) interface{} {
 	return v
 }
 
-func flattenComputeDiskDiskEncryptionKeyKms_key_self_link(v interface{}) interface{} {
+func flattenComputeDiskDiskEncryptionKeyKmsKeySelfLink(v interface{}) interface{} {
 	return v
 }
 
@@ -998,7 +998,7 @@ func flattenComputeDiskSourceSnapshotEncryptionKey(v interface{}) interface{} {
 	transformed["raw_key"] =
 		flattenComputeDiskSourceSnapshotEncryptionKeyRawKey(original["rawKey"])
 	transformed["kms_key_self_link"] =
-		flattenComputeDiskSourceSnapshotEncryptionKeyKms_key_self_link(original["kmsKeyName"])
+		flattenComputeDiskSourceSnapshotEncryptionKeyKmsKeySelfLink(original["kmsKeyName"])
 	transformed["sha256"] =
 		flattenComputeDiskSourceSnapshotEncryptionKeySha256(original["sha256"])
 	return []interface{}{transformed}
@@ -1007,7 +1007,7 @@ func flattenComputeDiskSourceSnapshotEncryptionKeyRawKey(v interface{}) interfac
 	return v
 }
 
-func flattenComputeDiskSourceSnapshotEncryptionKeyKms_key_self_link(v interface{}) interface{} {
+func flattenComputeDiskSourceSnapshotEncryptionKeyKmsKeySelfLink(v interface{}) interface{} {
 	return v
 }
 
@@ -1089,11 +1089,11 @@ func expandComputeDiskSourceImageEncryptionKey(v interface{}, d *schema.Resource
 		transformed["sha256"] = transformedSha256
 	}
 
-	transformedKms_key_self_link, err := expandComputeDiskSourceImageEncryptionKeyKms_key_self_link(original["kms_key_self_link"], d, config)
+	transformedKmsKeySelfLink, err := expandComputeDiskSourceImageEncryptionKeyKmsKeySelfLink(original["kms_key_self_link"], d, config)
 	if err != nil {
 		return nil, err
-	} else if val := reflect.ValueOf(transformedKms_key_self_link); val.IsValid() && !isEmptyValue(val) {
-		transformed["kmsKeyName"] = transformedKms_key_self_link
+	} else if val := reflect.ValueOf(transformedKmsKeySelfLink); val.IsValid() && !isEmptyValue(val) {
+		transformed["kmsKeyName"] = transformedKmsKeySelfLink
 	}
 
 	return transformed, nil
@@ -1107,7 +1107,7 @@ func expandComputeDiskSourceImageEncryptionKeySha256(v interface{}, d *schema.Re
 	return v, nil
 }
 
-func expandComputeDiskSourceImageEncryptionKeyKms_key_self_link(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
+func expandComputeDiskSourceImageEncryptionKeyKmsKeySelfLink(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 
@@ -1134,11 +1134,11 @@ func expandComputeDiskDiskEncryptionKey(v interface{}, d *schema.ResourceData, c
 		transformed["sha256"] = transformedSha256
 	}
 
-	transformedKms_key_self_link, err := expandComputeDiskDiskEncryptionKeyKms_key_self_link(original["kms_key_self_link"], d, config)
+	transformedKmsKeySelfLink, err := expandComputeDiskDiskEncryptionKeyKmsKeySelfLink(original["kms_key_self_link"], d, config)
 	if err != nil {
 		return nil, err
-	} else if val := reflect.ValueOf(transformedKms_key_self_link); val.IsValid() && !isEmptyValue(val) {
-		transformed["kmsKeyName"] = transformedKms_key_self_link
+	} else if val := reflect.ValueOf(transformedKmsKeySelfLink); val.IsValid() && !isEmptyValue(val) {
+		transformed["kmsKeyName"] = transformedKmsKeySelfLink
 	}
 
 	return transformed, nil
@@ -1152,7 +1152,7 @@ func expandComputeDiskDiskEncryptionKeySha256(v interface{}, d *schema.ResourceD
 	return v, nil
 }
 
-func expandComputeDiskDiskEncryptionKeyKms_key_self_link(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
+func expandComputeDiskDiskEncryptionKeyKmsKeySelfLink(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 
@@ -1180,11 +1180,11 @@ func expandComputeDiskSourceSnapshotEncryptionKey(v interface{}, d *schema.Resou
 		transformed["rawKey"] = transformedRawKey
 	}
 
-	transformedKms_key_self_link, err := expandComputeDiskSourceSnapshotEncryptionKeyKms_key_self_link(original["kms_key_self_link"], d, config)
+	transformedKmsKeySelfLink, err := expandComputeDiskSourceSnapshotEncryptionKeyKmsKeySelfLink(original["kms_key_self_link"], d, config)
 	if err != nil {
 		return nil, err
-	} else if val := reflect.ValueOf(transformedKms_key_self_link); val.IsValid() && !isEmptyValue(val) {
-		transformed["kmsKeyName"] = transformedKms_key_self_link
+	} else if val := reflect.ValueOf(transformedKmsKeySelfLink); val.IsValid() && !isEmptyValue(val) {
+		transformed["kmsKeyName"] = transformedKmsKeySelfLink
 	}
 
 	transformedSha256, err := expandComputeDiskSourceSnapshotEncryptionKeySha256(original["sha256"], d, config)
@@ -1201,7 +1201,7 @@ func expandComputeDiskSourceSnapshotEncryptionKeyRawKey(v interface{}, d *schema
 	return v, nil
 }
 
-func expandComputeDiskSourceSnapshotEncryptionKeyKms_key_self_link(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
+func expandComputeDiskSourceSnapshotEncryptionKeyKmsKeySelfLink(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 
@@ -1274,17 +1274,15 @@ func resourceComputeDiskEncoder(d *schema.ResourceData, meta interface{}, obj ma
 }
 
 func resourceComputeDiskDecoder(d *schema.ResourceData, meta interface{}, res map[string]interface{}) (map[string]interface{}, error) {
-	// The response for crypto keys often includes the version of the key which needs to be removed
-	// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
-	reg := regexp.MustCompile("/cryptoKeyVersions")
-
 	if v, ok := res["diskEncryptionKey"]; ok {
 		original := v.(map[string]interface{})
 		transformed := make(map[string]interface{})
 		// The raw key won't be returned, so we need to use the original.
 		transformed["rawKey"] = d.Get("disk_encryption_key.0.raw_key")
 		transformed["sha256"] = original["sha256"]
-		transformed["kmsKeyName"] = reg.Split(original["kmsKeyName"].(string), 2)[0]
+		// The response for crypto keys often includes the version of the key which needs to be removed
+		// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+		transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
 		res["diskEncryptionKey"] = transformed
 	}
 
@@ -1294,7 +1292,9 @@ func resourceComputeDiskDecoder(d *schema.ResourceData, meta interface{}, res ma
 		// The raw key won't be returned, so we need to use the original.
 		transformed["rawKey"] = d.Get("source_image_encryption_key.0.raw_key")
 		transformed["sha256"] = original["sha256"]
-		transformed["kmsKeyName"] = reg.Split(original["kmsKeyName"].(string), 2)[0]
+		// The response for crypto keys often includes the version of the key which needs to be removed
+		// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+		transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
 		res["sourceImageEncryptionKey"] = transformed
 	}
 
@@ -1304,7 +1304,9 @@ func resourceComputeDiskDecoder(d *schema.ResourceData, meta interface{}, res ma
 		// The raw key won't be returned, so we need to use the original.
 		transformed["rawKey"] = d.Get("source_snapshot_encryption_key.0.raw_key")
 		transformed["sha256"] = original["sha256"]
-		transformed["kmsKeyName"] = reg.Split(original["kmsKeyName"].(string), 2)[0]
+		// The response for crypto keys often includes the version of the key which needs to be removed
+		// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+		transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
 		res["sourceSnapshotEncryptionKey"] = transformed
 	}
 

--- a/google-beta/resource_compute_disk.go
+++ b/google-beta/resource_compute_disk.go
@@ -1280,9 +1280,11 @@ func resourceComputeDiskDecoder(d *schema.ResourceData, meta interface{}, res ma
 		// The raw key won't be returned, so we need to use the original.
 		transformed["rawKey"] = d.Get("disk_encryption_key.0.raw_key")
 		transformed["sha256"] = original["sha256"]
+
 		// The response for crypto keys often includes the version of the key which needs to be removed
 		// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
 		transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
+
 		res["diskEncryptionKey"] = transformed
 	}
 
@@ -1292,9 +1294,11 @@ func resourceComputeDiskDecoder(d *schema.ResourceData, meta interface{}, res ma
 		// The raw key won't be returned, so we need to use the original.
 		transformed["rawKey"] = d.Get("source_image_encryption_key.0.raw_key")
 		transformed["sha256"] = original["sha256"]
+
 		// The response for crypto keys often includes the version of the key which needs to be removed
 		// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
 		transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
+
 		res["sourceImageEncryptionKey"] = transformed
 	}
 
@@ -1304,9 +1308,11 @@ func resourceComputeDiskDecoder(d *schema.ResourceData, meta interface{}, res ma
 		// The raw key won't be returned, so we need to use the original.
 		transformed["rawKey"] = d.Get("source_snapshot_encryption_key.0.raw_key")
 		transformed["sha256"] = original["sha256"]
+
 		// The response for crypto keys often includes the version of the key which needs to be removed
 		// format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
 		transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
+
 		res["sourceSnapshotEncryptionKey"] = transformed
 	}
 

--- a/google-beta/resource_compute_disk_test.go
+++ b/google-beta/resource_compute_disk_test.go
@@ -362,6 +362,39 @@ func TestAccComputeDisk_encryption(t *testing.T) {
 	})
 }
 
+func TestAccComputeDisk_encryptionKMS(t *testing.T) {
+	skipIfEnvNotSet(t, "GOOGLE_PROJECT_NUMBER")
+	t.Parallel()
+
+	serviceAgent := fmt.Sprintf("service-%s@compute-system.iam.gserviceaccount.com", os.Getenv("GOOGLE_PROJECT_NUMBER"))
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	keyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var disk compute.Disk
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeDiskDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeDisk_encryptionKMS(serviceAgent, getTestProjectFromEnv(), diskName, keyRingName, keyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeDiskExists(
+						"google_compute_disk.foobar", &disk),
+					testAccCheckEncryptionKey(
+						"google_compute_disk.foobar", &disk),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_disk.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeDisk_deleteDetach(t *testing.T) {
 	t.Parallel()
 
@@ -728,6 +761,51 @@ resource "google_compute_disk" "foobar" {
 		raw_key = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
 	}
 }`, diskName)
+}
+
+func testAccComputeDisk_encryptionKMS(serviceAgent, project, diskName, keyRingName, keyName string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-9"
+	project = "debian-cloud"
+}
+
+resource "google_project_iam_member" "kms-project-binding" {
+  project = "%s"
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:%s"
+}
+
+resource "google_kms_crypto_key_iam_binding" "kms-key-binding" {
+  crypto_key_id = "${google_kms_crypto_key.my_crypto_key.self_link}"
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:%s",
+  ]
+}
+
+resource "google_kms_key_ring" "my_key_ring" {
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "my_crypto_key" {
+  name     = "%s"
+  key_ring = "${google_kms_key_ring.my_key_ring.self_link}"
+}
+
+resource "google_compute_disk" "foobar" {
+	name = "%s"
+	image = "${data.google_compute_image.my_image.self_link}"
+	size = 10
+	type = "pd-ssd"
+	zone = "us-central1-a"
+
+	disk_encryption_key {
+    kms_key_self_link = "${google_kms_crypto_key.my_crypto_key.self_link}"
+  }
+}`, project, serviceAgent, serviceAgent, keyRingName, keyName, diskName)
 }
 
 func testAccComputeDisk_deleteDetach(instanceName, diskName string) string {

--- a/google-beta/resource_compute_disk_test.go
+++ b/google-beta/resource_compute_disk_test.go
@@ -354,9 +354,6 @@ func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 	importID := fmt.Sprintf("%s/%s/%s", pid, "us-central1-a", diskName)
 	var disk compute.Disk
 
-	fmt.Println("ZOMGZOMG")
-	fmt.Println(testAccComputeDisk_encryptionKMS(pid, pname, org, billingAccount, diskName, keyRingName, keyName))
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -737,31 +734,32 @@ func testAccComputeDisk_encryptionKMS(pid, pname, org, billing, diskName, keyRin
 resource "google_project" "project" {
   project_id      = "%s"
   name            = "%s"
-	org_id          = "%s"
-	billing_account = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
 }
 
 data "google_compute_image" "my_image" {
-	family  = "debian-9"
-	project = "debian-cloud"
+  family  = "debian-9"
+  project = "debian-cloud"
 }
 
 resource "google_project_services" "apis" {
   project = "${google_project.project.project_id}"
+
   services = [
-		"oslogin.googleapis.com",
+    "oslogin.googleapis.com",
     "compute.googleapis.com",
     "cloudkms.googleapis.com",
-		"appengine.googleapis.com"
+    "appengine.googleapis.com",
   ]
 }
 
 resource "google_project_iam_member" "kms-project-binding" {
   project = "${google_project.project.project_id}"
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-	member  = "serviceAccount:service-${google_project.project.number}@compute-system.iam.gserviceaccount.com"
-	
-	depends_on = ["google_project_services.apis"]
+  member  = "serviceAccount:service-${google_project.project.number}@compute-system.iam.gserviceaccount.com"
+
+  depends_on = ["google_project_services.apis"]
 }
 
 resource "google_kms_crypto_key_iam_binding" "kms-key-binding" {
@@ -770,17 +768,17 @@ resource "google_kms_crypto_key_iam_binding" "kms-key-binding" {
 
   members = [
     "serviceAccount:service-${google_project.project.number}@compute-system.iam.gserviceaccount.com",
-	]
+  ]
 
-	depends_on = ["google_project_services.apis"]
+  depends_on = ["google_project_services.apis"]
 }
 
 resource "google_kms_key_ring" "my_key_ring" {
-	name     = "%s"
-	project  = "${google_project.project.project_id}"
-	location = "us-central1"
-	
-	depends_on = ["google_project_services.apis"]
+  name     = "%s"
+  project  = "${google_project.project.project_id}"
+  location = "us-central1"
+
+  depends_on = ["google_project_services.apis"]
 }
 
 resource "google_kms_crypto_key" "my_crypto_key" {
@@ -789,22 +787,23 @@ resource "google_kms_crypto_key" "my_crypto_key" {
 }
 
 resource "google_compute_disk" "foobar" {
-	name = "%s"
-	image = "${data.google_compute_image.my_image.self_link}"
-	size = 10
-	type = "pd-ssd"
-	zone = "us-central1-a"
-	project  = "${google_project.project.project_id}"
+  name    = "%s"
+  image   = "${data.google_compute_image.my_image.self_link}"
+  size    = 10
+  type    = "pd-ssd"
+  zone    = "us-central1-a"
+  project = "${google_project.project.project_id}"
 
-	disk_encryption_key {
+  disk_encryption_key {
     kms_key_self_link = "${google_kms_crypto_key.my_crypto_key.self_link}"
-	}
-	
-	depends_on = [
-		"google_kms_crypto_key_iam_binding.kms-key-binding",
-		"google_project_iam_member.kms-project-binding"
-	]
-}`, pid, pname, org, billing, keyRingName, keyName, diskName)
+  }
+
+  depends_on = [
+    "google_kms_crypto_key_iam_binding.kms-key-binding",
+    "google_project_iam_member.kms-project-binding",
+  ]
+}
+`, pid, pname, org, billing, keyRingName, keyName, diskName)
 }
 
 func testAccComputeDisk_deleteDetach(instanceName, diskName string) string {

--- a/website/docs/r/compute_disk.html.markdown
+++ b/website/docs/r/compute_disk.html.markdown
@@ -169,6 +169,13 @@ The `source_image_encryption_key` block supports:
   The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
   encryption key that protects this resource.
 
+* `kms_key_self_link` -
+  (Optional)
+  The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
+  in the cloud console. In order to use this additional
+  IAM permissions need to be set on the Compute Engine Service Agent. See
+  https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
+
 The `disk_encryption_key` block supports:
 
 * `raw_key` -
@@ -180,12 +187,26 @@ The `disk_encryption_key` block supports:
   The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
   encryption key that protects this resource.
 
+* `kms_key_self_link` -
+  (Optional)
+  The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
+  in the cloud console. In order to use this additional
+  IAM permissions need to be set on the Compute Engine Service Agent. See
+  https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
+
 The `source_snapshot_encryption_key` block supports:
 
 * `raw_key` -
   (Optional)
   Specifies a 256-bit customer-supplied encryption key, encoded in
   RFC 4648 base64 to either encrypt or decrypt this resource.
+
+* `kms_key_self_link` -
+  (Optional)
+  The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
+  in the cloud console. In order to use this additional
+  IAM permissions need to be set on the Compute Engine Service Agent. See
+  https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
 
 * `sha256` -
   The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied

--- a/website/docs/r/compute_disk.html.markdown
+++ b/website/docs/r/compute_disk.html.markdown
@@ -212,11 +212,6 @@ The `source_snapshot_encryption_key` block supports:
   The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied
   encryption key that protects this resource.
 
-* (Deprecated) `disk_encryption_key_raw`:  This is an alias for
-  `disk_encryption_key.raw_key`.  It is deprecated to enhance
-  consistency with `source_image_encryption_key` and
-  `source_snapshot_encryption_key`.
-
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:
@@ -255,11 +250,6 @@ In addition to the arguments listed above, the following computed attributes are
   used.
 * `self_link` - The URI of the created resource.
 
-
-* (Deprecated) `disk_encryption_key_sha256`: This is an alias for
-  `disk_encryption_key.sha256`.  It is deprecated to enhance
-  consistency with `source_image_encryption_key` and
-  `source_snapshot_encryption_key`.
 
 ## Timeouts
 


### PR DESCRIPTION
Allows a user to pass the self link to a KMS managed key in order to encyrpt
and decrypt the disks.

This patch has been hand coded by running Magic Modules in a future branch and
back ported into the google-beta provider. This is so that we can release KMS
support before the beta split is fully automated. It includes changes from a
few PR's including deprecating the raw_key helper and adding this feature.