### PR TITLE
Support cloud sql private ip

### DIFF
--- a/google-beta/resource_sql_database_instance.go
+++ b/google-beta/resource_sql_database_instance.go
@@ -632,6 +632,7 @@ func expandIpConfiguration(configured []interface{}) *sqladmin.IpConfiguration {
 		RequireSsl:         _ipConfiguration["require_ssl"].(bool),
 		PrivateNetwork:     _ipConfiguration["private_network"].(string),
 		AuthorizedNetworks: expandAuthorizedNetworks(_ipConfiguration["authorized_networks"].(*schema.Set).List()),
+		ForceSendFields:    []string{"Ipv4Enabled"},
 	}
 }
 func expandAuthorizedNetworks(configured []interface{}) []*sqladmin.AclEntry {

--- a/google-beta/resource_sql_database_instance.go
+++ b/google-beta/resource_sql_database_instance.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/api/sqladmin/v1beta4"
 )
 
-const peerNetworkLinkRegex = "projects/(" + ProjectRegex + ")/global/networks/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))$"
+const privateNetworkLinkRegex = "projects/(" + ProjectRegex + ")/global/networks/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))$"
 
 var sqlDatabaseAuthorizedNetWorkSchemaElem *schema.Resource = &schema.Resource{
 	Schema: map[string]*schema.Schema{
@@ -185,8 +185,8 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 									"private_network": &schema.Schema{
 										Type:             schema.TypeString,
 										Optional:         true,
-										ValidateFunc:     validateRegexp(peerNetworkLinkRegex),
-                                        DiffSuppressFunc: compareSelfLinkRelativePaths,
+										ValidateFunc:     validateRegexp(privateNetworkLinkRegex),
+										DiffSuppressFunc: compareSelfLinkRelativePaths,
 									},
 								},
 							},
@@ -622,6 +622,7 @@ func expandIpConfiguration(configured []interface{}) *sqladmin.IpConfiguration {
 	}
 
 	_ipConfiguration := configured[0].(map[string]interface{})
+
 	return &sqladmin.IpConfiguration{
 		Ipv4Enabled:        _ipConfiguration["ipv4_enabled"].(bool),
 		RequireSsl:         _ipConfiguration["require_ssl"].(bool),
@@ -676,15 +677,6 @@ func expandBackupConfiguration(configured []interface{}) *sqladmin.BackupConfigu
 		StartTime:        _backupConfiguration["start_time"].(string),
 	}
 }
-
-func expandComputePrivateNetwork(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
-	f, err := parseGlobalFieldValue("private_network", v.(string), "project", d, config, true)
-	if err != nil {
-		return nil, fmt.Errorf("Invalid value for network: %s", err)
-	}
-	return f.RelativeLink(), nil
-}
-
 
 func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)

--- a/google-beta/resource_sql_database_instance.go
+++ b/google-beta/resource_sql_database_instance.go
@@ -264,12 +264,16 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"ip_address": &schema.Schema{
+			"ip_addresses": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ip_address": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": &schema.Schema{
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -706,9 +710,8 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("replica_configuration", flattenReplicaConfiguration(instance.ReplicaConfiguration, d)); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance Replica Configuration")
 	}
-
 	ipAddresses := flattenIpAddresses(instance.IpAddresses)
-	if err := d.Set("ip_address", ipAddresses); err != nil {
+	if err := d.Set("ip_addresses", ipAddresses); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance IP Addresses")
 	}
 
@@ -961,6 +964,7 @@ func flattenIpAddresses(ipAddresses []*sqladmin.IpMapping) []map[string]interfac
 	for _, ip := range ipAddresses {
 		data := map[string]interface{}{
 			"ip_address":     ip.IpAddress,
+			"type":           ip.Type,
 			"time_to_retire": ip.TimeToRetire,
 		}
 


### PR DESCRIPTION
Here is my first attempt at adding Cloud SQL private network support.  I am new to Go, so I will need some guidance on how to improve this code and add the necessary tests.  Also, I could not disable public IP even when I set ip_configuration.ipv4_enabled to false.