### PR TITLE
Implemented support for VPC Connection Peering

### DIFF
--- a/google-beta/config.go
+++ b/google-beta/config.go
@@ -40,6 +40,7 @@ import (
 	"google.golang.org/api/redis/v1beta1"
 	"google.golang.org/api/runtimeconfig/v1beta1"
 	"google.golang.org/api/servicemanagement/v1"
+	"google.golang.org/api/servicenetworking/v1beta"
 	"google.golang.org/api/serviceusage/v1beta1"
 	"google.golang.org/api/sourcerepo/v1"
 	"google.golang.org/api/spanner/v1"
@@ -90,6 +91,7 @@ type Config struct {
 	clientCloudFunctions         *cloudfunctions.Service
 	clientCloudIoT               *cloudiot.Service
 	clientAppEngine              *appengine.APIService
+	clientServiceNetworking      *servicenetworking.APIService
 
 	bigtableClientFactory *BigtableClientFactory
 }
@@ -376,6 +378,13 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 	c.clientComposer.UserAgent = userAgent
+
+	log.Printf("[INFO] Instantiating Service Networking Client...")
+	c.clientServiceNetworking, err = servicenetworking.New(client)
+	if err != nil {
+		return err
+	}
+	c.clientServiceNetworking.UserAgent = userAgent
 
 	return nil
 }

--- a/google-beta/provider.go
+++ b/google-beta/provider.go
@@ -196,6 +196,7 @@ func Provider() terraform.ResourceProvider {
 				"google_spanner_database_iam_binding":          ResourceIamBindingWithImport(IamSpannerDatabaseSchema, NewSpannerDatabaseIamUpdater, SpannerDatabaseIdParseFunc),
 				"google_spanner_database_iam_member":           ResourceIamMemberWithImport(IamSpannerDatabaseSchema, NewSpannerDatabaseIamUpdater, SpannerDatabaseIdParseFunc),
 				"google_spanner_database_iam_policy":           ResourceIamPolicyWithImport(IamSpannerDatabaseSchema, NewSpannerDatabaseIamUpdater, SpannerDatabaseIdParseFunc),
+				"google_service_networking_connection":         resourceServiceNetworkingConnection(),
 				"google_sql_database":                          resourceSqlDatabase(),
 				"google_sql_database_instance":                 resourceSqlDatabaseInstance(),
 				"google_sql_user":                              resourceSqlUser(),

--- a/google-beta/resource_service_networking_connection.go
+++ b/google-beta/resource_service_networking_connection.go
@@ -1,0 +1,232 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/servicenetworking/v1beta"
+)
+
+func resourceServiceNetworkingConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceNetworkingConnectionCreate,
+		Read:   resourceServiceNetworkingConnectionRead,
+		Update: resourceServiceNetworkingConnectionUpdate,
+		Delete: resourceServiceNetworkingConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceNetworkingConnectionImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"network": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// NOTE(craigatgoogle): This field is weird, it's required to make the Insert/List calls, however it's defined
+			// in the API as an output field called "peering", which uses "-" as a delimeter instead of ".". To alleviate user
+			// confusion I've opted to model the gcloud CLI's approach, calling the field "service" and accepting the same
+			// format as the CLI with the "." delimiter.
+			// See: https://cloud.google.com/vpc/docs/configure-private-services-access#creating-connection
+			"service": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"reserved_peering_ranges": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceServiceNetworkingConnectionCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	network := d.Get("network").(string)
+	serviceNetworkingNetworkName, err := retrieveServiceNetworkingNetworkName(config, network)
+	if err != nil {
+		return fmt.Errorf("Failed to find Service Networking Connection, err: %s", err)
+	}
+
+	connection := &servicenetworking.Connection{
+		Network: serviceNetworkingNetworkName,
+	}
+
+	var reservedPeeringRanges []string
+	for _, reservedPeeringRange := range d.Get("reserved_peering_ranges").([]interface{}) {
+		reservedPeeringRanges = append(reservedPeeringRanges, reservedPeeringRange.(string))
+	}
+	connection.ReservedPeeringRanges = reservedPeeringRanges
+
+	parentService := formatParentService(d.Get("service").(string))
+	op, err := config.clientServiceNetworking.Services.Connections.Create(parentService, connection).Do()
+	if err != nil {
+		return err
+	}
+
+	if err := serviceNetworkingOperationWait(config, op, "Create Service Networking Connection"); err != nil {
+		return err
+	}
+
+	connectionId := &connectionId{
+		Network: network,
+		Service: d.Get("service").(string),
+	}
+
+	d.SetId(connectionId.Id())
+
+	if err := resourceServiceNetworkingConnectionRead(d, meta); err != nil {
+		d.SetId("")
+		return err
+	}
+
+	return nil
+}
+
+func resourceServiceNetworkingConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	connectionId, err := parseConnectionId(d.Id())
+	if err != nil {
+		return fmt.Errorf("Failed to find Service Networking Connection, err: %s", err)
+	}
+
+	serviceNetworkingNetworkName, err := retrieveServiceNetworkingNetworkName(config, connectionId.Network)
+	if err != nil {
+		return fmt.Errorf("Failed to find Service Networking Connection, err: %s", err)
+	}
+
+	parentService := formatParentService(connectionId.Service)
+	listCall := config.clientServiceNetworking.Services.Connections.List(parentService)
+	listCall.Network(serviceNetworkingNetworkName)
+	response, err := listCall.Do()
+	if err != nil {
+		return err
+	}
+
+	var connection *servicenetworking.Connection
+	for _, c := range response.Connections {
+		if c.Network == serviceNetworkingNetworkName {
+			connection = c
+			break
+		}
+	}
+
+	if connection == nil {
+		return fmt.Errorf("Failed to find Service Networking Connection, network: %s service: %s", connectionId.Network, connectionId.Service)
+	}
+
+	d.Set("network", connectionId.Network)
+	d.Set("service", connectionId.Service)
+	d.Set("reserved_peering_ranges", connection.ReservedPeeringRanges)
+	return nil
+}
+
+// NOTE(craigatgoogle): The API for this resource doesn't define an update, however the behavior
+// of Create serves as a de facto update by overwriting connections with the duplicate
+// tuples: (network/service).
+func resourceServiceNetworkingConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceServiceNetworkingConnectionCreate(d, meta)
+}
+
+// NOTE(craigatgoogle): This resource doesn't have a defined Delete method, however an un-documented
+// behavior is for the Connection to be deleted when its associated network is deleted. This is
+// helpeful for acctest cleanup.
+func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta interface{}) error {
+	connectionId, err := parseConnectionId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[WARNING] Service Networking Connection resources cannot be deleted from GCP. This Connection (network: %s, service: %s) will be removed from Terraform state, but will still be present on the server.", connectionId.Network, connectionId.Service)
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceServiceNetworkingConnectionImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	connectionId, err := parseConnectionId(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("network", connectionId.Network)
+	d.Set("service", connectionId.Service)
+	return []*schema.ResourceData{d}, nil
+}
+
+// NOTE(craigatgoogle): The Connection resource in this API doesn't have an Id field, so inorder
+// to support the Read method, we create an Id using the tuple(Network, Service).
+type connectionId struct {
+	Network string
+	Service string
+}
+
+func (id *connectionId) Id() string {
+	return fmt.Sprintf("%s:%s", url.QueryEscape(id.Network), url.QueryEscape(id.Service))
+}
+
+func parseConnectionId(id string) (*connectionId, error) {
+	res := strings.Split(id, ":")
+
+	if len(res) != 2 {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, value: %s", id)
+	}
+
+	network, err := url.QueryUnescape(res[0])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, invalid network, err: %s", err)
+	} else if len(network) == 0 {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, empty network")
+	}
+
+	service, err := url.QueryUnescape(res[1])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, invalid service, err: %s", err)
+	} else if len(service) == 0 {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, empty service")
+	}
+
+	return &connectionId{
+		Network: network,
+		Service: service,
+	}, nil
+}
+
+// NOTE(craigatgoogle): An out of band aspect of this API is that it uses a unique formatting of network
+// different from the standard self_link URI. It requires a call to the resource manager to get the project
+// number for the current project.
+func retrieveServiceNetworkingNetworkName(config *Config, network string) (string, error) {
+	pid := config.Project
+	if pid == "" {
+		return "", fmt.Errorf("Could not determine project")
+	}
+
+	project, err := config.clientResourceManager.Projects.Get(pid).Do()
+	if err != nil {
+		return "", fmt.Errorf("Failed to retrieve project, pid: %s, err: %s", pid, err)
+	}
+
+	// This bit of logic is to support both network.self_link and network.name
+	// being specified in the config.
+	networkTokens := strings.Split(network, "/")
+	if len(networkTokens) == 0 {
+		return "", fmt.Errorf("Failed to parse network")
+	}
+	networkName := networkTokens[len(networkTokens)-1]
+
+	// return the network name formatting unique to this API
+	return fmt.Sprintf("projects/%v/global/networks/%v", project.ProjectNumber, networkName), nil
+
+}
+
+// NOTE(craigatgoogle): An out of band aspect of this API is that it requires the service name to be
+// formatted as "services/<serviceName>"
+func formatParentService(service string) string {
+	return fmt.Sprintf("services/%s", service)
+}

--- a/google-beta/resource_service_networking_connection_test.go
+++ b/google-beta/resource_service_networking_connection_test.go
@@ -85,8 +85,8 @@ resource "google_compute_global_address" "foobar" {
 
 resource "google_service_networking_connection" "foobar" {
 	network       = "${google_compute_network.foobar.self_link}"
-        service       = "%s"
-        reserved_peering_ranges = ["${google_compute_global_address.foobar.name}"]
+	service       = "%s"
+	reserved_peering_ranges = ["${google_compute_global_address.foobar.name}"]
 }
 `, networkName, addressRangeName, serviceName)
 }

--- a/google-beta/resource_service_networking_connection_test.go
+++ b/google-beta/resource_service_networking_connection_test.go
@@ -1,0 +1,92 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccServiceNetworkingConnectionCreate(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServiceNetworkingConnection(
+					fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+					fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+					"servicenetworking.googleapis.com",
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_service_networking_connection.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+}
+
+func TestAccServiceNetworkingConnectionUpdate(t *testing.T) {
+	t.Parallel()
+
+	network := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServiceNetworkingConnection(
+					network,
+					fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+					"servicenetworking.googleapis.com",
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_service_networking_connection.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: testAccServiceNetworkingConnection(
+					network,
+					fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+					"servicenetworking.googleapis.com",
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_service_networking_connection.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+}
+
+func testAccServiceNetworkingConnection(networkName, addressRangeName, serviceName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+	name       = "%s"
+}
+
+resource "google_compute_global_address" "foobar" {
+	name          = "%s"
+	purpose       = "VPC_PEERING"
+	address_type = "INTERNAL"
+	prefix_length = 16
+	network       = "${google_compute_network.foobar.self_link}"
+}
+
+resource "google_service_networking_connection" "foobar" {
+	network       = "${google_compute_network.foobar.self_link}"
+        service       = "%s"
+        reserved_peering_ranges = ["${google_compute_global_address.foobar.name}"]
+}
+`, networkName, addressRangeName, serviceName)
+}

--- a/google-beta/service_networking_operation.go
+++ b/google-beta/service_networking_operation.go
@@ -17,7 +17,6 @@ type ServiceNetworkingOperationWaiter struct {
 
 func (w *ServiceNetworkingOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] self_link: %s", w.Op.Name)
 		op, err := w.Service.Operations.Get(w.Op.Name).Do()
 
 		if e, ok := err.(*googleapi.Error); ok && (e.Code == 429 || e.Code == 503) {

--- a/google-beta/service_networking_operation.go
+++ b/google-beta/service_networking_operation.go
@@ -1,0 +1,83 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/servicenetworking/v1beta"
+)
+
+type ServiceNetworkingOperationWaiter struct {
+	Service *servicenetworking.APIService
+	Op      *servicenetworking.Operation
+}
+
+func (w *ServiceNetworkingOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[DEBUG] self_link: %s", w.Op.Name)
+		op, err := w.Service.Operations.Get(w.Op.Name).Do()
+
+		if e, ok := err.(*googleapi.Error); ok && (e.Code == 429 || e.Code == 503) {
+			return w.Op, fmt.Sprintf("%v", op.Done), nil
+		} else if err != nil {
+			return nil, "", err
+		}
+
+		log.Printf("[DEBUG] Got done: %v  when asking for operation %q", op.Done, w.Op.Name)
+
+		return op, fmt.Sprintf("%v", op.Done), nil
+	}
+}
+
+func (w *ServiceNetworkingOperationWaiter) Conf() *resource.StateChangeConf {
+	return &resource.StateChangeConf{
+		Pending: []string{"false"},
+		Target:  []string{"true"},
+		Refresh: w.RefreshFunc(),
+	}
+}
+
+// ServiceNetworkingOperationError wraps servicenetworking.Status and implements
+// the error interface so it can be returned.
+type ServiceNetworkingOperationError servicenetworking.Status
+
+func (e ServiceNetworkingOperationError) Error() string {
+	return e.Message
+}
+
+func serviceNetworkingOperationWait(config *Config, op *servicenetworking.Operation, activity string) error {
+	return serviceNetworkingOperationWaitTime(config, op, activity, 10)
+}
+
+func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Operation, activity string, timeoutMinutes int) error {
+	if op.Done {
+		if op.Error != nil {
+			return ServiceNetworkingOperationError(*op.Error)
+		}
+		return nil
+	}
+
+	w := &ServiceNetworkingOperationWaiter{
+		Service: config.clientServiceNetworking,
+		Op:      op,
+	}
+
+	state := w.Conf()
+	state.Timeout = time.Duration(timeoutMinutes) * time.Minute
+	state.MinTimeout = 2 * time.Second
+	state.Delay = 5 * time.Second
+	opRaw, err := state.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for %s (op %s): %s", activity, op.Name, err)
+	}
+
+	op = opRaw.(*servicenetworking.Operation)
+	if op.Error != nil {
+		return ServiceNetworkingOperationError(*op.Error)
+	}
+
+	return nil
+}

--- a/vendor/google.golang.org/api/servicenetworking/v1beta/servicenetworking-api.json
+++ b/vendor/google.golang.org/api/servicenetworking/v1beta/servicenetworking-api.json
@@ -1,0 +1,1879 @@
+{
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
+        },
+        "https://www.googleapis.com/auth/service.management": {
+          "description": "Manage your Google API service configuration"
+        }
+      }
+    }
+  },
+  "basePath": "",
+  "baseUrl": "https://servicenetworking.googleapis.com/",
+  "batchPath": "batch",
+  "canonicalName": "Service Networking",
+  "description": "Provides automatic management of network configurations necessary for certain services.",
+  "discoveryVersion": "v1",
+  "documentationLink": "https://cloud.google.com/service-infrastructure/docs/service-networking/getting-started",
+  "fullyEncodeReservedExpansion": true,
+  "icons": {
+    "x16": "http://www.google.com/images/icons/product/search-16.gif",
+    "x32": "http://www.google.com/images/icons/product/search-32.gif"
+  },
+  "id": "servicenetworking:v1beta",
+  "kind": "discovery#restDescription",
+  "name": "servicenetworking",
+  "ownerDomain": "google.com",
+  "ownerName": "Google",
+  "parameters": {
+    "$.xgafv": {
+      "description": "V1 error format.",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "access_token": {
+      "description": "OAuth access token.",
+      "location": "query",
+      "type": "string"
+    },
+    "alt": {
+      "default": "json",
+      "description": "Data format for response.",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query",
+      "type": "string"
+    },
+    "callback": {
+      "description": "JSONP",
+      "location": "query",
+      "type": "string"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "location": "query",
+      "type": "string"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "location": "query",
+      "type": "string"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "location": "query",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "default": "true",
+      "description": "Returns response with indentations and line breaks.",
+      "location": "query",
+      "type": "boolean"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "location": "query",
+      "type": "string"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "location": "query",
+      "type": "string"
+    },
+    "upload_protocol": {
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "location": "query",
+      "type": "string"
+    }
+  },
+  "protocol": "rest",
+  "resources": {
+    "operations": {
+      "methods": {
+        "get": {
+          "description": "Gets the latest state of a long-running operation.  Clients can use this\nmethod to poll the operation result at intervals as recommended by the API\nservice.",
+          "flatPath": "v1beta/operations/{operationsId}",
+          "httpMethod": "GET",
+          "id": "servicenetworking.operations.get",
+          "parameterOrder": [
+            "name"
+          ],
+          "parameters": {
+            "name": {
+              "description": "The name of the operation resource.",
+              "location": "path",
+              "pattern": "^operations/[^/]+$",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "v1beta/{+name}",
+          "response": {
+            "$ref": "Operation"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        }
+      }
+    },
+    "services": {
+      "methods": {
+        "addSubnetwork": {
+          "description": "Service producers use this method to provision a new subnet in\npeered service shared VPC network.\nIt will validate previously provided allocated ranges, find\nnon-conflicting sub-range of requested size (expressed in\nnumber of leading bits of ipv4 network mask, as in CIDR range\nnotation). It will then create a subnetwork in the request\nregion. The subsequent call will try to reuse the\nsubnetwork previously created if subnetwork name, region and\nprefix length of the IP range match.\nOperation\u003cresponse: Subnetwork\u003e",
+          "flatPath": "v1beta/services/{servicesId}/{servicesId1}/{servicesId2}:addSubnetwork",
+          "httpMethod": "POST",
+          "id": "servicenetworking.services.addSubnetwork",
+          "parameterOrder": [
+            "parent"
+          ],
+          "parameters": {
+            "parent": {
+              "description": "Required. This is a 'tenant' project in the service producer organization.\nservices/{service}/{collection-id}/{resource-id}\n{collection id} is the cloud resource collection type representing the\ntenant project. Only 'projects' are currently supported.\n{resource id} is the tenant project numeric id: '123456'.\n{service} the name of the peering service, for example\n'service-peering.example.com'. This service must be activated.\nin the consumer project.",
+              "location": "path",
+              "pattern": "^services/[^/]+/[^/]+/[^/]+$",
+              "required": true,
+              "type": "string"
+            }
+          },
+          "path": "v1beta/{+parent}:addSubnetwork",
+          "request": {
+            "$ref": "AddSubnetworkRequest"
+          },
+          "response": {
+            "$ref": "Operation"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        }
+      },
+      "resources": {
+        "connections": {
+          "methods": {
+            "create": {
+              "description": "To connect service to a VPC network peering connection\nmust be established prior to service provisioning.\nThis method must be invoked by the consumer VPC network administrator\nIt will establish a permanent peering connection with a shared\nnetwork created in the service producer organization and register a\nallocated IP range(s) to be used for service subnetwork provisioning.\nThis connection will be used for all supported services in the service\nproducer organization, so it only needs to be invoked once.\nOperation\u003cresponse: Connection\u003e.",
+              "flatPath": "v1beta/services/{servicesId}/connections",
+              "httpMethod": "POST",
+              "id": "servicenetworking.services.connections.create",
+              "parameterOrder": [
+                "parent"
+              ],
+              "parameters": {
+                "parent": {
+                  "description": "Provider peering service that is managing peering connectivity for a\nservice provider organization.\nFor Google services that support this functionality it is\n'services/servicenetworking.googleapis.com'.",
+                  "location": "path",
+                  "pattern": "^services/[^/]+$",
+                  "required": true,
+                  "type": "string"
+                }
+              },
+              "path": "v1beta/{+parent}/connections",
+              "request": {
+                "$ref": "Connection"
+              },
+              "response": {
+                "$ref": "Operation"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/service.management"
+              ]
+            },
+            "list": {
+              "description": "Service consumers use this method to list configured peering connection for\nthe given service and consumer network.",
+              "flatPath": "v1beta/services/{servicesId}/connections",
+              "httpMethod": "GET",
+              "id": "servicenetworking.services.connections.list",
+              "parameterOrder": [
+                "parent"
+              ],
+              "parameters": {
+                "network": {
+                  "description": "Network name in the consumer project.   This network must have been\nalready peered with a shared VPC network using CreateConnection\nmethod.\nMust be in a form 'projects/{project}/global/networks/{network}'.\n{project} is a project number, as in '12345'\n{network} is network name.",
+                  "location": "query",
+                  "type": "string"
+                },
+                "parent": {
+                  "description": "Provider peering service that is managing peering connectivity for a\nservice provider organization.\nFor Google services that support this functionality it is\n'services/servicenetworking.googleapis.com'.",
+                  "location": "path",
+                  "pattern": "^services/[^/]+$",
+                  "required": true,
+                  "type": "string"
+                }
+              },
+              "path": "v1beta/{+parent}/connections",
+              "response": {
+                "$ref": "ListConnectionsResponse"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/service.management"
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "revision": "20181026",
+  "rootUrl": "https://servicenetworking.googleapis.com/",
+  "schemas": {
+    "AddSubnetworkRequest": {
+      "description": "Request to create a subnetwork in a previously peered service network.",
+      "id": "AddSubnetworkRequest",
+      "properties": {
+        "consumer": {
+          "description": "Required. Resource representing service consumer. It may be different from\nthe project number in consumer network parameter in case of that network\nbeing a shared VPC network. In that case, Service Networking will validate\nthat this resource belongs to that shared VPC.\nFor example 'projects/123456'.",
+          "type": "string"
+        },
+        "consumerNetwork": {
+          "description": "Required. Network name in the consumer project.   This network must have been\nalready peered with a shared VPC network using CreateConnection\nmethod.\nMust be in a form 'projects/{project}/global/networks/{network}'.\n{project} is a project number, as in '12345'\n{network} is network name.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional. Description of the subnetwork.",
+          "type": "string"
+        },
+        "ipPrefixLength": {
+          "description": "Required. The prefix length of the IP range.\nUse usual CIDR range notation.\nFor example, '30' to provision subnet with x.x.x.x/30 CIDR range.\nActual range will be determined using allocated range for the consumer\npeered network and returned in the result.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "region": {
+          "description": "Required. Cloud [region](/compute/docs/reference/rest/v1/regions) for the new\nsubnetwork.",
+          "type": "string"
+        },
+        "requestedAddress": {
+          "description": "Optional. The starting address of a range. The address must be a valid\nIPv4 address in the x.x.x.x format. This value combined with the IP prefix\nrange is the CIDR range for the subnet. The range must be within the\nallocated range that is assigned to the private connection. If the CIDR\nrange isn't available, the call fails.",
+          "type": "string"
+        },
+        "subnetwork": {
+          "description": "Required. Name for the new subnetwork.\nMust be a legal [subnetwork](compute/docs/reference/rest/v1/subnetworks)\nname.",
+          "type": "string"
+        },
+        "subnetworkUsers": {
+          "description": "Optional. List of members that will be granted 'compute.networkUser' role\non the newly added subnetwork.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Api": {
+      "description": "Api is a light-weight descriptor for an API Interface.\n\nInterfaces are also described as \"protocol buffer services\" in some contexts,\nsuch as by the \"service\" keyword in a .proto file, but they are different\nfrom API Services, which represent a concrete implementation of an interface\nas opposed to simply a description of methods and bindings. They are also\nsometimes simply referred to as \"APIs\" in other contexts, such as the name of\nthis message itself. See https://cloud.google.com/apis/design/glossary for\ndetailed terminology.",
+      "id": "Api",
+      "properties": {
+        "methods": {
+          "description": "The methods of this interface, in unspecified order.",
+          "items": {
+            "$ref": "Method"
+          },
+          "type": "array"
+        },
+        "mixins": {
+          "description": "Included interfaces. See Mixin.",
+          "items": {
+            "$ref": "Mixin"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "The fully qualified name of this interface, including package name\nfollowed by the interface's simple name.",
+          "type": "string"
+        },
+        "options": {
+          "description": "Any metadata attached to the interface.",
+          "items": {
+            "$ref": "Option"
+          },
+          "type": "array"
+        },
+        "sourceContext": {
+          "$ref": "SourceContext",
+          "description": "Source context for the protocol buffer service represented by this\nmessage."
+        },
+        "syntax": {
+          "description": "The source syntax of the service.",
+          "enum": [
+            "SYNTAX_PROTO2",
+            "SYNTAX_PROTO3"
+          ],
+          "enumDescriptions": [
+            "Syntax `proto2`.",
+            "Syntax `proto3`."
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "A version string for this interface. If specified, must have the form\n`major-version.minor-version`, as in `1.10`. If the minor version is\nomitted, it defaults to zero. If the entire version field is empty, the\nmajor version is derived from the package name, as outlined below. If the\nfield is not empty, the version in the package name will be verified to be\nconsistent with what is provided here.\n\nThe versioning schema uses [semantic\nversioning](http://semver.org) where the major version number\nindicates a breaking change and the minor version an additive,\nnon-breaking change. Both version numbers are signals to users\nwhat to expect from different versions, and should be carefully\nchosen based on the product plan.\n\nThe major version is also reflected in the package name of the\ninterface, which must end in `v\u003cmajor-version\u003e`, as in\n`google.feature.v1`. For major versions 0 and 1, the suffix can\nbe omitted. Zero major versions must only be used for\nexperimental, non-GA interfaces.\n",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AuthProvider": {
+      "description": "Configuration for an anthentication provider, including support for\n[JSON Web Token (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32).",
+      "id": "AuthProvider",
+      "properties": {
+        "audiences": {
+          "description": "The list of JWT\n[audiences](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.3).\nthat are allowed to access. A JWT containing any of these audiences will\nbe accepted. When this setting is absent, only JWTs with audience\n\"https://Service_name/API_name\"\nwill be accepted. For example, if no audiences are in the setting,\nLibraryService API will only accept JWTs with the following audience\n\"https://library-example.googleapis.com/google.example.library.v1.LibraryService\".\n\nExample:\n\n    audiences: bookstore_android.apps.googleusercontent.com,\n               bookstore_web.apps.googleusercontent.com",
+          "type": "string"
+        },
+        "authorizationUrl": {
+          "description": "Redirect URL if JWT token is required but no present or is expired.\nImplement authorizationUrl of securityDefinitions in OpenAPI spec.",
+          "type": "string"
+        },
+        "id": {
+          "description": "The unique identifier of the auth provider. It will be referred to by\n`AuthRequirement.provider_id`.\n\nExample: \"bookstore_auth\".",
+          "type": "string"
+        },
+        "issuer": {
+          "description": "Identifies the principal that issued the JWT. See\nhttps://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.1\nUsually a URL or an email address.\n\nExample: https://securetoken.google.com\nExample: 1234567-compute@developer.gserviceaccount.com",
+          "type": "string"
+        },
+        "jwksUri": {
+          "description": "URL of the provider's public key set to validate signature of the JWT. See\n[OpenID Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).\nOptional if the key set document:\n - can be retrieved from\n   [OpenID Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html\n   of the issuer.\n - can be inferred from the email domain of the issuer (e.g. a Google service account).\n\nExample: https://www.googleapis.com/oauth2/v1/certs",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AuthRequirement": {
+      "description": "User-defined authentication requirements, including support for\n[JSON Web Token (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32).",
+      "id": "AuthRequirement",
+      "properties": {
+        "audiences": {
+          "description": "NOTE: This will be deprecated soon, once AuthProvider.audiences is\nimplemented and accepted in all the runtime components.\n\nThe list of JWT\n[audiences](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.3).\nthat are allowed to access. A JWT containing any of these audiences will\nbe accepted. When this setting is absent, only JWTs with audience\n\"https://Service_name/API_name\"\nwill be accepted. For example, if no audiences are in the setting,\nLibraryService API will only accept JWTs with the following audience\n\"https://library-example.googleapis.com/google.example.library.v1.LibraryService\".\n\nExample:\n\n    audiences: bookstore_android.apps.googleusercontent.com,\n               bookstore_web.apps.googleusercontent.com",
+          "type": "string"
+        },
+        "providerId": {
+          "description": "id from authentication provider.\n\nExample:\n\n    provider_id: bookstore_auth",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Authentication": {
+      "description": "`Authentication` defines the authentication configuration for an API.\n\nExample for an API targeted for external use:\n\n    name: calendar.googleapis.com\n    authentication:\n      providers:\n      - id: google_calendar_auth\n        jwks_uri: https://www.googleapis.com/oauth2/v1/certs\n        issuer: https://securetoken.google.com\n      rules:\n      - selector: \"*\"\n        requirements:\n          provider_id: google_calendar_auth",
+      "id": "Authentication",
+      "properties": {
+        "providers": {
+          "description": "Defines a set of authentication providers that a service supports.",
+          "items": {
+            "$ref": "AuthProvider"
+          },
+          "type": "array"
+        },
+        "rules": {
+          "description": "A list of authentication rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "items": {
+            "$ref": "AuthenticationRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "AuthenticationRule": {
+      "description": "Authentication rules for the service.\n\nBy default, if a method has any authentication requirements, every request\nmust include a valid credential matching one of the requirements.\nIt's an error to include more than one kind of credential in a single\nrequest.\n\nIf a method doesn't have any auth requirements, request credentials will be\nignored.",
+      "id": "AuthenticationRule",
+      "properties": {
+        "allowWithoutCredential": {
+          "description": "If true, the service accepts API keys without any other credential.",
+          "type": "boolean"
+        },
+        "oauth": {
+          "$ref": "OAuthRequirements",
+          "description": "The requirements for OAuth credentials."
+        },
+        "requirements": {
+          "description": "Requirements for additional authentication providers.",
+          "items": {
+            "$ref": "AuthRequirement"
+          },
+          "type": "array"
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AuthorizationConfig": {
+      "description": "Configuration of authorization.\n\nThis section determines the authorization provider, if unspecified, then no\nauthorization check will be done.\n\nExample:\n\n    experimental:\n      authorization:\n        provider: firebaserules.googleapis.com",
+      "id": "AuthorizationConfig",
+      "properties": {
+        "provider": {
+          "description": "The name of the authorization provider, such as\nfirebaserules.googleapis.com.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Backend": {
+      "description": "`Backend` defines the backend configuration for a service.",
+      "id": "Backend",
+      "properties": {
+        "rules": {
+          "description": "A list of API backend rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "items": {
+            "$ref": "BackendRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "BackendRule": {
+      "description": "A backend rule provides configuration for an individual API element.",
+      "id": "BackendRule",
+      "properties": {
+        "address": {
+          "description": "The address of the API backend.",
+          "type": "string"
+        },
+        "deadline": {
+          "description": "The number of seconds to wait for a response from a request.  The default\ndeadline for gRPC is infinite (no deadline) and HTTP requests is 5 seconds.",
+          "format": "double",
+          "type": "number"
+        },
+        "minDeadline": {
+          "description": "Minimum deadline in seconds needed for this method. Calls having deadline\nvalue lower than this will be rejected.",
+          "format": "double",
+          "type": "number"
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Billing": {
+      "description": "Billing related configuration of the service.\n\nThe following example shows how to configure monitored resources and metrics\nfor billing:\n\n    monitored_resources:\n    - type: library.googleapis.com/branch\n      labels:\n      - key: /city\n        description: The city where the library branch is located in.\n      - key: /name\n        description: The name of the branch.\n    metrics:\n    - name: library.googleapis.com/book/borrowed_count\n      metric_kind: DELTA\n      value_type: INT64\n    billing:\n      consumer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        metrics:\n        - library.googleapis.com/book/borrowed_count",
+      "id": "Billing",
+      "properties": {
+        "consumerDestinations": {
+          "description": "Billing configurations for sending metrics to the consumer project.\nThere can be multiple consumer destinations per service, each one must have\na different monitored resource type. A metric can be used in at most\none consumer destination.",
+          "items": {
+            "$ref": "BillingDestination"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "BillingDestination": {
+      "description": "Configuration of a specific billing destination (Currently only support\nbill against consumer project).",
+      "id": "BillingDestination",
+      "properties": {
+        "metrics": {
+          "description": "Names of the metrics to report to this billing destination.\nEach name must be defined in Service.metrics section.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "monitoredResource": {
+          "description": "The monitored resource type. The type must be defined in\nService.monitored_resources section.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Connection": {
+      "description": "Message returning the created service connection.",
+      "id": "Connection",
+      "properties": {
+        "network": {
+          "description": "Name of VPC network connected with service producer network.\nMust be in a form 'projects/{project}/global/networks/{network}'.\n{project} is a project number, as in '12345'\n{network} is a network name.",
+          "type": "string"
+        },
+        "peering": {
+          "description": "Output only.\nName of the peering connection that is created by the peering service.",
+          "type": "string"
+        },
+        "reservedPeeringRanges": {
+          "description": "Named IP address range(s) of PEERING type allocated for this service\nprovider.\nNote that invoking this method with a different range when connection is\nalready established will not modify already provisioned service\nproducer subnetworks.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Context": {
+      "description": "`Context` defines which contexts an API requests.\n\nExample:\n\n    context:\n      rules:\n      - selector: \"*\"\n        requested:\n        - google.rpc.context.ProjectContext\n        - google.rpc.context.OriginContext\n\nThe above specifies that all methods in the API request\n`google.rpc.context.ProjectContext` and\n`google.rpc.context.OriginContext`.\n\nAvailable context types are defined in package\n`google.rpc.context`.\n\nThis also provides mechanism to whitelist any protobuf message extension that\ncan be sent in grpc metadata using “x-goog-ext-\u003cextension_id\u003e-bin” and\n“x-goog-ext-\u003cextension_id\u003e-jspb” format. For example, list any service\nspecific protobuf types that can appear in grpc metadata as follows in your\nyaml file:\n\nExample:\n\n    context:\n      rules:\n       - selector: \"google.example.library.v1.LibraryService.CreateBook\"\n         allowed_request_extensions:\n         - google.foo.v1.NewExtension\n         allowed_response_extensions:\n         - google.foo.v1.NewExtension\n\nYou can also specify extension ID instead of fully qualified extension name\nhere.",
+      "id": "Context",
+      "properties": {
+        "rules": {
+          "description": "A list of RPC context rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "items": {
+            "$ref": "ContextRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ContextRule": {
+      "description": "A context rule provides information about the context for an individual API\nelement.",
+      "id": "ContextRule",
+      "properties": {
+        "allowedRequestExtensions": {
+          "description": "A list of full type names or extension IDs of extensions allowed in grpc\nside channel from client to backend.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowedResponseExtensions": {
+          "description": "A list of full type names or extension IDs of extensions allowed in grpc\nside channel from backend to client.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "provided": {
+          "description": "A list of full type names of provided contexts.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "requested": {
+          "description": "A list of full type names of requested contexts.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Control": {
+      "description": "Selects and configures the service controller used by the service.  The\nservice controller handles features like abuse, quota, billing, logging,\nmonitoring, etc.",
+      "id": "Control",
+      "properties": {
+        "environment": {
+          "description": "The service control environment to use. If empty, no control plane\nfeature (like quota and billing) will be enabled.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CustomError": {
+      "description": "Customize service error responses.  For example, list any service\nspecific protobuf types that can appear in error detail lists of\nerror responses.\n\nExample:\n\n    custom_error:\n      types:\n      - google.foo.v1.CustomError\n      - google.foo.v1.AnotherError",
+      "id": "CustomError",
+      "properties": {
+        "rules": {
+          "description": "The list of custom error rules that apply to individual API messages.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "items": {
+            "$ref": "CustomErrorRule"
+          },
+          "type": "array"
+        },
+        "types": {
+          "description": "The list of custom error detail types, e.g. 'google.foo.v1.CustomError'.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "CustomErrorRule": {
+      "description": "A custom error rule.",
+      "id": "CustomErrorRule",
+      "properties": {
+        "isErrorType": {
+          "description": "Mark this message as possible payload in error response.  Otherwise,\nobjects of this type will be filtered when they appear in error payload.",
+          "type": "boolean"
+        },
+        "selector": {
+          "description": "Selects messages to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CustomHttpPattern": {
+      "description": "A custom pattern is used for defining custom HTTP verb.",
+      "id": "CustomHttpPattern",
+      "properties": {
+        "kind": {
+          "description": "The name of this custom HTTP verb.",
+          "type": "string"
+        },
+        "path": {
+          "description": "The path matched by this custom verb.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Documentation": {
+      "description": "`Documentation` provides the information for describing a service.\n\nExample:\n\u003cpre\u003e\u003ccode\u003edocumentation:\n  summary: \u003e\n    The Google Calendar API gives access\n    to most calendar features.\n  pages:\n  - name: Overview\n    content: \u0026#40;== include google/foo/overview.md ==\u0026#41;\n  - name: Tutorial\n    content: \u0026#40;== include google/foo/tutorial.md ==\u0026#41;\n    subpages;\n    - name: Java\n      content: \u0026#40;== include google/foo/tutorial_java.md ==\u0026#41;\n  rules:\n  - selector: google.calendar.Calendar.Get\n    description: \u003e\n      ...\n  - selector: google.calendar.Calendar.Put\n    description: \u003e\n      ...\n\u003c/code\u003e\u003c/pre\u003e\nDocumentation is provided in markdown syntax. In addition to\nstandard markdown features, definition lists, tables and fenced\ncode blocks are supported. Section headers can be provided and are\ninterpreted relative to the section nesting of the context where\na documentation fragment is embedded.\n\nDocumentation from the IDL is merged with documentation defined\nvia the config at normalization time, where documentation provided\nby config rules overrides IDL provided.\n\nA number of constructs specific to the API platform are supported\nin documentation text.\n\nIn order to reference a proto element, the following\nnotation can be used:\n\u003cpre\u003e\u003ccode\u003e\u0026#91;fully.qualified.proto.name]\u0026#91;]\u003c/code\u003e\u003c/pre\u003e\nTo override the display text used for the link, this can be used:\n\u003cpre\u003e\u003ccode\u003e\u0026#91;display text]\u0026#91;fully.qualified.proto.name]\u003c/code\u003e\u003c/pre\u003e\nText can be excluded from doc using the following notation:\n\u003cpre\u003e\u003ccode\u003e\u0026#40;-- internal comment --\u0026#41;\u003c/code\u003e\u003c/pre\u003e\n\nA few directives are available in documentation. Note that\ndirectives must appear on a single line to be properly\nidentified. The `include` directive includes a markdown file from\nan external source:\n\u003cpre\u003e\u003ccode\u003e\u0026#40;== include path/to/file ==\u0026#41;\u003c/code\u003e\u003c/pre\u003e\nThe `resource_for` directive marks a message to be the resource of\na collection in REST view. If it is not specified, tools attempt\nto infer the resource from the operations in a collection:\n\u003cpre\u003e\u003ccode\u003e\u0026#40;== resource_for v1.shelves.books ==\u0026#41;\u003c/code\u003e\u003c/pre\u003e\nThe directive `suppress_warning` does not directly affect documentation\nand is documented together with service config validation.",
+      "id": "Documentation",
+      "properties": {
+        "documentationRootUrl": {
+          "description": "The URL to the root of documentation.",
+          "type": "string"
+        },
+        "overview": {
+          "description": "Declares a single overview page. For example:\n\u003cpre\u003e\u003ccode\u003edocumentation:\n  summary: ...\n  overview: \u0026#40;== include overview.md ==\u0026#41;\n\u003c/code\u003e\u003c/pre\u003e\nThis is a shortcut for the following declaration (using pages style):\n\u003cpre\u003e\u003ccode\u003edocumentation:\n  summary: ...\n  pages:\n  - name: Overview\n    content: \u0026#40;== include overview.md ==\u0026#41;\n\u003c/code\u003e\u003c/pre\u003e\nNote: you cannot specify both `overview` field and `pages` field.",
+          "type": "string"
+        },
+        "pages": {
+          "description": "The top level pages for the documentation set.",
+          "items": {
+            "$ref": "Page"
+          },
+          "type": "array"
+        },
+        "rules": {
+          "description": "A list of documentation rules that apply to individual API elements.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "items": {
+            "$ref": "DocumentationRule"
+          },
+          "type": "array"
+        },
+        "summary": {
+          "description": "A short summary of what the service does. Can only be provided by\nplain text.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DocumentationRule": {
+      "description": "A documentation rule provides information about individual API elements.",
+      "id": "DocumentationRule",
+      "properties": {
+        "deprecationDescription": {
+          "description": "Deprecation description of the selected element(s). It can be provided if an\nelement is marked as `deprecated`.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the selected API(s).",
+          "type": "string"
+        },
+        "selector": {
+          "description": "The selector is a comma-separated list of patterns. Each pattern is a\nqualified name of the element which may end in \"*\", indicating a wildcard.\nWildcards are only allowed at the end and for a whole component of the\nqualified name, i.e. \"foo.*\" is ok, but not \"foo.b*\" or \"foo.*.bar\". To\nspecify a default for all applicable elements, the whole pattern \"*\"\nis used.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Endpoint": {
+      "description": "`Endpoint` describes a network endpoint that serves a set of APIs.\nA service may expose any number of endpoints, and all endpoints share the\nsame service configuration, such as quota configuration and monitoring\nconfiguration.\n\nExample service configuration:\n\n    name: library-example.googleapis.com\n    endpoints:\n      # Below entry makes 'google.example.library.v1.Library'\n      # API be served from endpoint address library-example.googleapis.com.\n      # It also allows HTTP OPTIONS calls to be passed to the backend, for\n      # it to decide whether the subsequent cross-origin request is\n      # allowed to proceed.\n    - name: library-example.googleapis.com\n      allow_cors: true",
+      "id": "Endpoint",
+      "properties": {
+        "aliases": {
+          "description": "DEPRECATED: This field is no longer supported. Instead of using aliases,\nplease specify multiple google.api.Endpoint for each of the intended\naliases.\n\nAdditional names that this endpoint will be hosted on.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowCors": {
+          "description": "Allowing\n[CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing), aka\ncross-domain traffic, would allow the backends served from this endpoint to\nreceive and respond to HTTP OPTIONS requests. The response will be used by\nthe browser to determine whether the subsequent cross-origin request is\nallowed to proceed.",
+          "type": "boolean"
+        },
+        "features": {
+          "description": "The list of features enabled on this endpoint.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "The canonical name of this endpoint.",
+          "type": "string"
+        },
+        "target": {
+          "description": "The specification of an Internet routable address of API frontend that will\nhandle requests to this [API Endpoint](https://cloud.google.com/apis/design/glossary).\nIt should be either a valid IPv4 address or a fully-qualified domain name.\nFor example, \"8.8.8.8\" or \"myservice.appspot.com\".",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Enum": {
+      "description": "Enum type definition.",
+      "id": "Enum",
+      "properties": {
+        "enumvalue": {
+          "description": "Enum value definitions.",
+          "items": {
+            "$ref": "EnumValue"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Enum type name.",
+          "type": "string"
+        },
+        "options": {
+          "description": "Protocol buffer options.",
+          "items": {
+            "$ref": "Option"
+          },
+          "type": "array"
+        },
+        "sourceContext": {
+          "$ref": "SourceContext",
+          "description": "The source context."
+        },
+        "syntax": {
+          "description": "The source syntax.",
+          "enum": [
+            "SYNTAX_PROTO2",
+            "SYNTAX_PROTO3"
+          ],
+          "enumDescriptions": [
+            "Syntax `proto2`.",
+            "Syntax `proto3`."
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EnumValue": {
+      "description": "Enum value definition.",
+      "id": "EnumValue",
+      "properties": {
+        "name": {
+          "description": "Enum value name.",
+          "type": "string"
+        },
+        "number": {
+          "description": "Enum value number.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "options": {
+          "description": "Protocol buffer options.",
+          "items": {
+            "$ref": "Option"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Experimental": {
+      "description": "Experimental service configuration. These configuration options can\nonly be used by whitelisted users.",
+      "id": "Experimental",
+      "properties": {
+        "authorization": {
+          "$ref": "AuthorizationConfig",
+          "description": "Authorization configuration."
+        }
+      },
+      "type": "object"
+    },
+    "Field": {
+      "description": "A single field of a message type.",
+      "id": "Field",
+      "properties": {
+        "cardinality": {
+          "description": "The field cardinality.",
+          "enum": [
+            "CARDINALITY_UNKNOWN",
+            "CARDINALITY_OPTIONAL",
+            "CARDINALITY_REQUIRED",
+            "CARDINALITY_REPEATED"
+          ],
+          "enumDescriptions": [
+            "For fields with unknown cardinality.",
+            "For optional fields.",
+            "For required fields. Proto2 syntax only.",
+            "For repeated fields."
+          ],
+          "type": "string"
+        },
+        "defaultValue": {
+          "description": "The string value of the default value of this field. Proto2 syntax only.",
+          "type": "string"
+        },
+        "jsonName": {
+          "description": "The field JSON name.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The field type.",
+          "enum": [
+            "TYPE_UNKNOWN",
+            "TYPE_DOUBLE",
+            "TYPE_FLOAT",
+            "TYPE_INT64",
+            "TYPE_UINT64",
+            "TYPE_INT32",
+            "TYPE_FIXED64",
+            "TYPE_FIXED32",
+            "TYPE_BOOL",
+            "TYPE_STRING",
+            "TYPE_GROUP",
+            "TYPE_MESSAGE",
+            "TYPE_BYTES",
+            "TYPE_UINT32",
+            "TYPE_ENUM",
+            "TYPE_SFIXED32",
+            "TYPE_SFIXED64",
+            "TYPE_SINT32",
+            "TYPE_SINT64"
+          ],
+          "enumDescriptions": [
+            "Field type unknown.",
+            "Field type double.",
+            "Field type float.",
+            "Field type int64.",
+            "Field type uint64.",
+            "Field type int32.",
+            "Field type fixed64.",
+            "Field type fixed32.",
+            "Field type bool.",
+            "Field type string.",
+            "Field type group. Proto2 syntax only, and deprecated.",
+            "Field type message.",
+            "Field type bytes.",
+            "Field type uint32.",
+            "Field type enum.",
+            "Field type sfixed32.",
+            "Field type sfixed64.",
+            "Field type sint32.",
+            "Field type sint64."
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The field name.",
+          "type": "string"
+        },
+        "number": {
+          "description": "The field number.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "oneofIndex": {
+          "description": "The index of the field type in `Type.oneofs`, for message or enumeration\ntypes. The first type has index 1; zero means the type is not in the list.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "options": {
+          "description": "The protocol buffer options.",
+          "items": {
+            "$ref": "Option"
+          },
+          "type": "array"
+        },
+        "packed": {
+          "description": "Whether to use alternative packed wire representation.",
+          "type": "boolean"
+        },
+        "typeUrl": {
+          "description": "The field type URL, without the scheme, for message or enumeration\ntypes. Example: `\"type.googleapis.com/google.protobuf.Timestamp\"`.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Http": {
+      "description": "Defines the HTTP configuration for an API service. It contains a list of\nHttpRule, each specifying the mapping of an RPC method\nto one or more HTTP REST API methods.",
+      "id": "Http",
+      "properties": {
+        "fullyDecodeReservedExpansion": {
+          "description": "When set to true, URL path parmeters will be fully URI-decoded except in\ncases of single segment matches in reserved expansion, where \"%2F\" will be\nleft encoded.\n\nThe default behavior is to not decode RFC 6570 reserved characters in multi\nsegment matches.",
+          "type": "boolean"
+        },
+        "rules": {
+          "description": "A list of HTTP configuration rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "items": {
+            "$ref": "HttpRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "HttpRule": {
+      "description": "# gRPC Transcoding\n\ngRPC Transcoding is a feature for mapping between a gRPC method and one or\nmore HTTP REST endpoints. It allows developers to build a single API service\nthat supports both gRPC APIs and REST APIs. Many systems, including [Google\nAPIs](https://github.com/googleapis/googleapis),\n[Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC\nGateway](https://github.com/grpc-ecosystem/grpc-gateway),\nand [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature\nand use it for large scale production services.\n\n`HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies\nhow different portions of the gRPC request message are mapped to the URL\npath, URL query parameters, and HTTP request body. It also controls how the\ngRPC response message is mapped to the HTTP response body. `HttpRule` is\ntypically specified as an `google.api.http` annotation on the gRPC method.\n\nEach mapping specifies a URL path template and an HTTP method. The path\ntemplate may refer to one or more fields in the gRPC request message, as long\nas each field is a non-repeated field with a primitive (non-message) type.\nThe path template controls how fields of the request message are mapped to\nthe URL path.\n\nExample:\n\n    service Messaging {\n      rpc GetMessage(GetMessageRequest) returns (Message) {\n        option (google.api.http) = {\n            get: \"/v1/{name=messages/*}\"\n        };\n      }\n    }\n    message GetMessageRequest {\n      string name = 1; // Mapped to URL path.\n    }\n    message Message {\n      string text = 1; // The resource content.\n    }\n\nThis enables an HTTP REST to gRPC mapping as below:\n\nHTTP | gRPC\n-----|-----\n`GET /v1/messages/123456`  | `GetMessage(name: \"messages/123456\")`\n\nAny fields in the request message which are not bound by the path template\nautomatically become HTTP query parameters if there is no HTTP request body.\nFor example:\n\n    service Messaging {\n      rpc GetMessage(GetMessageRequest) returns (Message) {\n        option (google.api.http) = {\n            get:\"/v1/messages/{message_id}\"\n        };\n      }\n    }\n    message GetMessageRequest {\n      message SubMessage {\n        string subfield = 1;\n      }\n      string message_id = 1; // Mapped to URL path.\n      int64 revision = 2;    // Mapped to URL query parameter `revision`.\n      SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.\n    }\n\nThis enables a HTTP JSON to RPC mapping as below:\n\nHTTP | gRPC\n-----|-----\n`GET /v1/messages/123456?revision=2\u0026sub.subfield=foo` | `GetMessage(message_id: \"123456\" revision: 2 sub: SubMessage(subfield: \"foo\"))`\n\nNote that fields which are mapped to URL query parameters must have a\nprimitive type or a repeated primitive type or a non-repeated message type.\nIn the case of a repeated type, the parameter can be repeated in the URL\nas `...?param=A\u0026param=B`. In the case of a message type, each field of the\nmessage is mapped to a separate parameter, such as\n`...?foo.a=A\u0026foo.b=B\u0026foo.c=C`.\n\nFor HTTP methods that allow a request body, the `body` field\nspecifies the mapping. Consider a REST update method on the\nmessage resource collection:\n\n    service Messaging {\n      rpc UpdateMessage(UpdateMessageRequest) returns (Message) {\n        option (google.api.http) = {\n          patch: \"/v1/messages/{message_id}\"\n          body: \"message\"\n        };\n      }\n    }\n    message UpdateMessageRequest {\n      string message_id = 1; // mapped to the URL\n      Message message = 2;   // mapped to the body\n    }\n\nThe following HTTP JSON to RPC mapping is enabled, where the\nrepresentation of the JSON in the request body is determined by\nprotos JSON encoding:\n\nHTTP | gRPC\n-----|-----\n`PATCH /v1/messages/123456 { \"text\": \"Hi!\" }` | `UpdateMessage(message_id: \"123456\" message { text: \"Hi!\" })`\n\nThe special name `*` can be used in the body mapping to define that\nevery field not bound by the path template should be mapped to the\nrequest body.  This enables the following alternative definition of\nthe update method:\n\n    service Messaging {\n      rpc UpdateMessage(Message) returns (Message) {\n        option (google.api.http) = {\n          patch: \"/v1/messages/{message_id}\"\n          body: \"*\"\n        };\n      }\n    }\n    message Message {\n      string message_id = 1;\n      string text = 2;\n    }\n\n\nThe following HTTP JSON to RPC mapping is enabled:\n\nHTTP | gRPC\n-----|-----\n`PATCH /v1/messages/123456 { \"text\": \"Hi!\" }` | `UpdateMessage(message_id: \"123456\" text: \"Hi!\")`\n\nNote that when using `*` in the body mapping, it is not possible to\nhave HTTP parameters, as all fields not bound by the path end in\nthe body. This makes this option more rarely used in practice when\ndefining REST APIs. The common usage of `*` is in custom methods\nwhich don't use the URL at all for transferring data.\n\nIt is possible to define multiple HTTP methods for one RPC by using\nthe `additional_bindings` option. Example:\n\n    service Messaging {\n      rpc GetMessage(GetMessageRequest) returns (Message) {\n        option (google.api.http) = {\n          get: \"/v1/messages/{message_id}\"\n          additional_bindings {\n            get: \"/v1/users/{user_id}/messages/{message_id}\"\n          }\n        };\n      }\n    }\n    message GetMessageRequest {\n      string message_id = 1;\n      string user_id = 2;\n    }\n\nThis enables the following two alternative HTTP JSON to RPC mappings:\n\nHTTP | gRPC\n-----|-----\n`GET /v1/messages/123456` | `GetMessage(message_id: \"123456\")`\n`GET /v1/users/me/messages/123456` | `GetMessage(user_id: \"me\" message_id: \"123456\")`\n\n## Rules for HTTP mapping\n\n1. Leaf request fields (recursive expansion nested messages in the request\n   message) are classified into three categories:\n   - Fields referred by the path template. They are passed via the URL path.\n   - Fields referred by the HttpRule.body. They are passed via the HTTP\n     request body.\n   - All other fields are passed via the URL query parameters, and the\n     parameter name is the field path in the request message. A repeated\n     field can be represented as multiple query parameters under the same\n     name.\n 2. If HttpRule.body is \"*\", there is no URL query parameter, all fields\n    are passed via URL path and HTTP request body.\n 3. If HttpRule.body is omitted, there is no HTTP request body, all\n    fields are passed via URL path and URL query parameters.\n\n### Path template syntax\n\n    Template = \"/\" Segments [ Verb ] ;\n    Segments = Segment { \"/\" Segment } ;\n    Segment  = \"*\" | \"**\" | LITERAL | Variable ;\n    Variable = \"{\" FieldPath [ \"=\" Segments ] \"}\" ;\n    FieldPath = IDENT { \".\" IDENT } ;\n    Verb     = \":\" LITERAL ;\n\nThe syntax `*` matches a single URL path segment. The syntax `**` matches\nzero or more URL path segments, which must be the last part of the URL path\nexcept the `Verb`.\n\nThe syntax `Variable` matches part of the URL path as specified by its\ntemplate. A variable template must not contain other variables. If a variable\nmatches a single path segment, its template may be omitted, e.g. `{var}`\nis equivalent to `{var=*}`.\n\nThe syntax `LITERAL` matches literal text in the URL path. If the `LITERAL`\ncontains any reserved character, such characters should be percent-encoded\nbefore the matching.\n\nIf a variable contains exactly one path segment, such as `\"{var}\"` or\n`\"{var=*}\"`, when such a variable is expanded into a URL path on the client\nside, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The\nserver side does the reverse decoding. Such variables show up in the\n[Discovery Document](https://developers.google.com/discovery/v1/reference/apis)\nas `{var}`.\n\nIf a variable contains multiple path segments, such as `\"{var=foo/*}\"`\nor `\"{var=**}\"`, when such a variable is expanded into a URL path on the\nclient side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.\nThe server side does the reverse decoding, except \"%2F\" and \"%2f\" are left\nunchanged. Such variables show up in the\n[Discovery Document](https://developers.google.com/discovery/v1/reference/apis)\nas `{+var}`.\n\n## Using gRPC API Service Configuration\n\ngRPC API Service Configuration (service config) is a configuration language\nfor configuring a gRPC service to become a user-facing product. The\nservice config is simply the YAML representation of the `google.api.Service`\nproto message.\n\nAs an alternative to annotating your proto file, you can configure gRPC\ntranscoding in your service config YAML files. You do this by specifying a\n`HttpRule` that maps the gRPC method to a REST endpoint, achieving the same\neffect as the proto annotation. This can be particularly useful if you\nhave a proto that is reused in multiple services. Note that any transcoding\nspecified in the service config will override any matching transcoding\nconfiguration in the proto.\n\nExample:\n\n    http:\n      rules:\n        # Selects a gRPC method and applies HttpRule to it.\n        - selector: example.v1.Messaging.GetMessage\n          get: /v1/messages/{message_id}/{sub.subfield}\n\n## Special notes\n\nWhen gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the\nproto to JSON conversion must follow the [proto3\nspecification](https://developers.google.com/protocol-buffers/docs/proto3#json).\n\nWhile the single segment variable follows the semantics of\n[RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String\nExpansion, the multi segment variable **does not** follow RFC 6570 Section\n3.2.3 Reserved Expansion. The reason is that the Reserved Expansion\ndoes not expand special characters like `?` and `#`, which would lead\nto invalid URLs. As the result, gRPC Transcoding uses a custom encoding\nfor multi segment variables.\n\nThe path variables **must not** refer to any repeated or mapped field,\nbecause client libraries are not capable of handling such variable expansion.\n\nThe path variables **must not** capture the leading \"/\" character. The reason\nis that the most common use case \"{var}\" does not capture the leading \"/\"\ncharacter. For consistency, all path variables must share the same behavior.\n\nRepeated message fields must not be mapped to URL query parameters, because\nno client library can support such complicated mapping.\n\nIf an API needs to use a JSON array for request or response body, it can map\nthe request or response body to a repeated field. However, some gRPC\nTranscoding implementations may not support this feature.",
+      "id": "HttpRule",
+      "properties": {
+        "additionalBindings": {
+          "description": "Additional HTTP bindings for the selector. Nested bindings must\nnot contain an `additional_bindings` field themselves (that is,\nthe nesting may only be one level deep).",
+          "items": {
+            "$ref": "HttpRule"
+          },
+          "type": "array"
+        },
+        "body": {
+          "description": "The name of the request field whose value is mapped to the HTTP request\nbody, or `*` for mapping all request fields not captured by the path\npattern to the HTTP body, or omitted for not having any HTTP request body.\n\nNOTE: the referred field must be present at the top-level of the request\nmessage type.",
+          "type": "string"
+        },
+        "custom": {
+          "$ref": "CustomHttpPattern",
+          "description": "The custom pattern is used for specifying an HTTP method that is not\nincluded in the `pattern` field, such as HEAD, or \"*\" to leave the\nHTTP method unspecified for this rule. The wild-card rule is useful\nfor services that provide content to Web (HTML) clients."
+        },
+        "delete": {
+          "description": "Maps to HTTP DELETE. Used for deleting a resource.",
+          "type": "string"
+        },
+        "get": {
+          "description": "Maps to HTTP GET. Used for listing and getting information about\nresources.",
+          "type": "string"
+        },
+        "patch": {
+          "description": "Maps to HTTP PATCH. Used for updating a resource.",
+          "type": "string"
+        },
+        "post": {
+          "description": "Maps to HTTP POST. Used for creating a resource or performing an action.",
+          "type": "string"
+        },
+        "put": {
+          "description": "Maps to HTTP PUT. Used for replacing a resource.",
+          "type": "string"
+        },
+        "responseBody": {
+          "description": "Optional. The name of the response field whose value is mapped to the HTTP\nresponse body. When omitted, the entire response message will be used\nas the HTTP response body.\n\nNOTE: The referred field must be present at the top-level of the response\nmessage type.",
+          "type": "string"
+        },
+        "selector": {
+          "description": "Selects a method to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "LabelDescriptor": {
+      "description": "A description of a label.",
+      "id": "LabelDescriptor",
+      "properties": {
+        "description": {
+          "description": "A human-readable description for the label.",
+          "type": "string"
+        },
+        "key": {
+          "description": "The label key.",
+          "type": "string"
+        },
+        "valueType": {
+          "description": "The type of data that can be assigned to the label.",
+          "enum": [
+            "STRING",
+            "BOOL",
+            "INT64"
+          ],
+          "enumDescriptions": [
+            "A variable-length string. This is the default.",
+            "Boolean; true or false.",
+            "A 64-bit signed integer."
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ListConnectionsResponse": {
+      "description": "ListConnectionsResponse is the response to list peering states for the\ngiven service and consumer project.",
+      "id": "ListConnectionsResponse",
+      "properties": {
+        "connections": {
+          "description": "The list of Connections.",
+          "items": {
+            "$ref": "Connection"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "LogDescriptor": {
+      "description": "A description of a log type. Example in YAML format:\n\n    - name: library.googleapis.com/activity_history\n      description: The history of borrowing and returning library items.\n      display_name: Activity\n      labels:\n      - key: /customer_id\n        description: Identifier of a library customer",
+      "id": "LogDescriptor",
+      "properties": {
+        "description": {
+          "description": "A human-readable description of this log. This information appears in\nthe documentation and can contain details.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "The human-readable name for this log. This information appears on\nthe user interface and should be concise.",
+          "type": "string"
+        },
+        "labels": {
+          "description": "The set of labels that are available to describe a specific log entry.\nRuntime requests that contain labels not specified here are\nconsidered invalid.",
+          "items": {
+            "$ref": "LabelDescriptor"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "The name of the log. It must be less than 512 characters long and can\ninclude the following characters: upper- and lower-case alphanumeric\ncharacters [A-Za-z0-9], and punctuation characters including\nslash, underscore, hyphen, period [/_-.].",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Logging": {
+      "description": "Logging configuration of the service.\n\nThe following example shows how to configure logs to be sent to the\nproducer and consumer projects. In the example, the `activity_history`\nlog is sent to both the producer and consumer projects, whereas the\n`purchase_history` log is only sent to the producer project.\n\n    monitored_resources:\n    - type: library.googleapis.com/branch\n      labels:\n      - key: /city\n        description: The city where the library branch is located in.\n      - key: /name\n        description: The name of the branch.\n    logs:\n    - name: activity_history\n      labels:\n      - key: /customer_id\n    - name: purchase_history\n    logging:\n      producer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        logs:\n        - activity_history\n        - purchase_history\n      consumer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        logs:\n        - activity_history",
+      "id": "Logging",
+      "properties": {
+        "consumerDestinations": {
+          "description": "Logging configurations for sending logs to the consumer project.\nThere can be multiple consumer destinations, each one must have a\ndifferent monitored resource type. A log can be used in at most\none consumer destination.",
+          "items": {
+            "$ref": "LoggingDestination"
+          },
+          "type": "array"
+        },
+        "producerDestinations": {
+          "description": "Logging configurations for sending logs to the producer project.\nThere can be multiple producer destinations, each one must have a\ndifferent monitored resource type. A log can be used in at most\none producer destination.",
+          "items": {
+            "$ref": "LoggingDestination"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "LoggingDestination": {
+      "description": "Configuration of a specific logging destination (the producer project\nor the consumer project).",
+      "id": "LoggingDestination",
+      "properties": {
+        "logs": {
+          "description": "Names of the logs to be sent to this destination. Each name must\nbe defined in the Service.logs section. If the log name is\nnot a domain scoped name, it will be automatically prefixed with\nthe service name followed by \"/\".",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "monitoredResource": {
+          "description": "The monitored resource type. The type must be defined in the\nService.monitored_resources section.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Method": {
+      "description": "Method represents a method of an API interface.",
+      "id": "Method",
+      "properties": {
+        "name": {
+          "description": "The simple name of this method.",
+          "type": "string"
+        },
+        "options": {
+          "description": "Any metadata attached to the method.",
+          "items": {
+            "$ref": "Option"
+          },
+          "type": "array"
+        },
+        "requestStreaming": {
+          "description": "If true, the request is streamed.",
+          "type": "boolean"
+        },
+        "requestTypeUrl": {
+          "description": "A URL of the input message type.",
+          "type": "string"
+        },
+        "responseStreaming": {
+          "description": "If true, the response is streamed.",
+          "type": "boolean"
+        },
+        "responseTypeUrl": {
+          "description": "The URL of the output message type.",
+          "type": "string"
+        },
+        "syntax": {
+          "description": "The source syntax of this method.",
+          "enum": [
+            "SYNTAX_PROTO2",
+            "SYNTAX_PROTO3"
+          ],
+          "enumDescriptions": [
+            "Syntax `proto2`.",
+            "Syntax `proto3`."
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "MetricDescriptor": {
+      "description": "Defines a metric type and its schema. Once a metric descriptor is created,\ndeleting or altering it stops data collection and makes the metric type's\nexisting data unusable.",
+      "id": "MetricDescriptor",
+      "properties": {
+        "description": {
+          "description": "A detailed description of the metric, which can be used in documentation.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "A concise name for the metric, which can be displayed in user interfaces.\nUse sentence case without an ending period, for example \"Request count\".\nThis field is optional but it is recommended to be set for any metrics\nassociated with user-visible concepts, such as Quota.",
+          "type": "string"
+        },
+        "labels": {
+          "description": "The set of labels that can be used to describe a specific\ninstance of this metric type. For example, the\n`appengine.googleapis.com/http/server/response_latencies` metric\ntype has a label for the HTTP response code, `response_code`, so\nyou can look at latencies for successful responses or just\nfor responses that failed.",
+          "items": {
+            "$ref": "LabelDescriptor"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "MetricDescriptorMetadata",
+          "description": "Optional. Metadata which can be used to guide usage of the metric."
+        },
+        "metricKind": {
+          "description": "Whether the metric records instantaneous values, changes to a value, etc.\nSome combinations of `metric_kind` and `value_type` might not be supported.",
+          "enum": [
+            "METRIC_KIND_UNSPECIFIED",
+            "GAUGE",
+            "DELTA",
+            "CUMULATIVE"
+          ],
+          "enumDescriptions": [
+            "Do not use this default value.",
+            "An instantaneous measurement of a value.",
+            "The change in a value during a time interval.",
+            "A value accumulated over a time interval.  Cumulative\nmeasurements in a time series should have the same start time\nand increasing end times, until an event resets the cumulative\nvalue to zero and sets a new start time for the following\npoints."
+          ],
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name of the metric descriptor.",
+          "type": "string"
+        },
+        "type": {
+          "description": "The metric type, including its DNS name prefix. The type is not\nURL-encoded.  All user-defined metric types have the DNS name\n`custom.googleapis.com` or `external.googleapis.com`.  Metric types should\nuse a natural hierarchical grouping. For example:\n\n    \"custom.googleapis.com/invoice/paid/amount\"\n    \"external.googleapis.com/prometheus/up\"\n    \"appengine.googleapis.com/http/server/response_latencies\"",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The unit in which the metric value is reported. It is only applicable\nif the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`. The\nsupported units are a subset of [The Unified Code for Units of\nMeasure](http://unitsofmeasure.org/ucum.html) standard:\n\n**Basic units (UNIT)**\n\n* `bit`   bit\n* `By`    byte\n* `s`     second\n* `min`   minute\n* `h`     hour\n* `d`     day\n\n**Prefixes (PREFIX)**\n\n* `k`     kilo    (10**3)\n* `M`     mega    (10**6)\n* `G`     giga    (10**9)\n* `T`     tera    (10**12)\n* `P`     peta    (10**15)\n* `E`     exa     (10**18)\n* `Z`     zetta   (10**21)\n* `Y`     yotta   (10**24)\n* `m`     milli   (10**-3)\n* `u`     micro   (10**-6)\n* `n`     nano    (10**-9)\n* `p`     pico    (10**-12)\n* `f`     femto   (10**-15)\n* `a`     atto    (10**-18)\n* `z`     zepto   (10**-21)\n* `y`     yocto   (10**-24)\n* `Ki`    kibi    (2**10)\n* `Mi`    mebi    (2**20)\n* `Gi`    gibi    (2**30)\n* `Ti`    tebi    (2**40)\n\n**Grammar**\n\nThe grammar also includes these connectors:\n\n* `/`    division (as an infix operator, e.g. `1/s`).\n* `.`    multiplication (as an infix operator, e.g. `GBy.d`)\n\nThe grammar for a unit is as follows:\n\n    Expression = Component { \".\" Component } { \"/\" Component } ;\n\n    Component = ( [ PREFIX ] UNIT | \"%\" ) [ Annotation ]\n              | Annotation\n              | \"1\"\n              ;\n\n    Annotation = \"{\" NAME \"}\" ;\n\nNotes:\n\n* `Annotation` is just a comment if it follows a `UNIT` and is\n   equivalent to `1` if it is used alone. For examples,\n   `{requests}/s == 1/s`, `By{transmitted}/s == By/s`.\n* `NAME` is a sequence of non-blank printable ASCII characters not\n   containing '{' or '}'.\n* `1` represents dimensionless value 1, such as in `1/s`.\n* `%` represents dimensionless value 1/100, and annotates values giving\n   a percentage.",
+          "type": "string"
+        },
+        "valueType": {
+          "description": "Whether the measurement is an integer, a floating-point number, etc.\nSome combinations of `metric_kind` and `value_type` might not be supported.",
+          "enum": [
+            "VALUE_TYPE_UNSPECIFIED",
+            "BOOL",
+            "INT64",
+            "DOUBLE",
+            "STRING",
+            "DISTRIBUTION",
+            "MONEY"
+          ],
+          "enumDescriptions": [
+            "Do not use this default value.",
+            "The value is a boolean.\nThis value type can be used only if the metric kind is `GAUGE`.",
+            "The value is a signed 64-bit integer.",
+            "The value is a double precision floating point number.",
+            "The value is a text string.\nThis value type can be used only if the metric kind is `GAUGE`.",
+            "The value is a `Distribution`.",
+            "The value is money."
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "MetricDescriptorMetadata": {
+      "description": "Additional annotations that can be used to guide the usage of a metric.",
+      "id": "MetricDescriptorMetadata",
+      "properties": {
+        "ingestDelay": {
+          "description": "The delay of data points caused by ingestion. Data points older than this\nage are guaranteed to be ingested and available to be read, excluding\ndata loss due to errors.",
+          "format": "google-duration",
+          "type": "string"
+        },
+        "launchStage": {
+          "description": "The launch stage of the metric definition.",
+          "enum": [
+            "LAUNCH_STAGE_UNSPECIFIED",
+            "EARLY_ACCESS",
+            "ALPHA",
+            "BETA",
+            "GA",
+            "DEPRECATED"
+          ],
+          "enumDescriptions": [
+            "Do not use this default value.",
+            "Early Access features are limited to a closed group of testers. To use\nthese features, you must sign up in advance and sign a Trusted Tester\nagreement (which includes confidentiality provisions). These features may\nbe unstable, changed in backward-incompatible ways, and are not\nguaranteed to be released.",
+            "Alpha is a limited availability test for releases before they are cleared\nfor widespread use. By Alpha, all significant design issues are resolved\nand we are in the process of verifying functionality. Alpha customers\nneed to apply for access, agree to applicable terms, and have their\nprojects whitelisted. Alpha releases don’t have to be feature complete,\nno SLAs are provided, and there are no technical support obligations, but\nthey will be far enough along that customers can actually use them in\ntest environments or for limited-use tests -- just like they would in\nnormal production cases.",
+            "Beta is the point at which we are ready to open a release for any\ncustomer to use. There are no SLA or technical support obligations in a\nBeta release. Products will be complete from a feature perspective, but\nmay have some open outstanding issues. Beta releases are suitable for\nlimited production use cases.",
+            "GA features are open to all developers and are considered stable and\nfully qualified for production use.",
+            "Deprecated features are scheduled to be shut down and removed. For more\ninformation, see the “Deprecation Policy” section of our [Terms of\nService](https://cloud.google.com/terms/)\nand the [Google Cloud Platform Subject to the Deprecation\nPolicy](https://cloud.google.com/terms/deprecation) documentation."
+          ],
+          "type": "string"
+        },
+        "samplePeriod": {
+          "description": "The sampling period of metric data points. For metrics which are written\nperiodically, consecutive data points are stored at this time interval,\nexcluding data loss due to errors. Metrics with a higher granularity have\na smaller sampling period.",
+          "format": "google-duration",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "MetricRule": {
+      "description": "Bind API methods to metrics. Binding a method to a metric causes that\nmetric's configured quota behaviors to apply to the method call.",
+      "id": "MetricRule",
+      "properties": {
+        "metricCosts": {
+          "additionalProperties": {
+            "format": "int64",
+            "type": "string"
+          },
+          "description": "Metrics to update when the selected methods are called, and the associated\ncost applied to each metric.\n\nThe key of the map is the metric name, and the values are the amount\nincreased for the metric against which the quota limits are defined.\nThe value must not be negative.",
+          "type": "object"
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Mixin": {
+      "description": "Declares an API Interface to be included in this interface. The including\ninterface must redeclare all the methods from the included interface, but\ndocumentation and options are inherited as follows:\n\n- If after comment and whitespace stripping, the documentation\n  string of the redeclared method is empty, it will be inherited\n  from the original method.\n\n- Each annotation belonging to the service config (http,\n  visibility) which is not set in the redeclared method will be\n  inherited.\n\n- If an http annotation is inherited, the path pattern will be\n  modified as follows. Any version prefix will be replaced by the\n  version of the including interface plus the root path if\n  specified.\n\nExample of a simple mixin:\n\n    package google.acl.v1;\n    service AccessControl {\n      // Get the underlying ACL object.\n      rpc GetAcl(GetAclRequest) returns (Acl) {\n        option (google.api.http).get = \"/v1/{resource=**}:getAcl\";\n      }\n    }\n\n    package google.storage.v2;\n    service Storage {\n      //       rpc GetAcl(GetAclRequest) returns (Acl);\n\n      // Get a data record.\n      rpc GetData(GetDataRequest) returns (Data) {\n        option (google.api.http).get = \"/v2/{resource=**}\";\n      }\n    }\n\nExample of a mixin configuration:\n\n    apis:\n    - name: google.storage.v2.Storage\n      mixins:\n      - name: google.acl.v1.AccessControl\n\nThe mixin construct implies that all methods in `AccessControl` are\nalso declared with same name and request/response types in\n`Storage`. A documentation generator or annotation processor will\nsee the effective `Storage.GetAcl` method after inherting\ndocumentation and annotations as follows:\n\n    service Storage {\n      // Get the underlying ACL object.\n      rpc GetAcl(GetAclRequest) returns (Acl) {\n        option (google.api.http).get = \"/v2/{resource=**}:getAcl\";\n      }\n      ...\n    }\n\nNote how the version in the path pattern changed from `v1` to `v2`.\n\nIf the `root` field in the mixin is specified, it should be a\nrelative path under which inherited HTTP paths are placed. Example:\n\n    apis:\n    - name: google.storage.v2.Storage\n      mixins:\n      - name: google.acl.v1.AccessControl\n        root: acls\n\nThis implies the following inherited HTTP annotation:\n\n    service Storage {\n      // Get the underlying ACL object.\n      rpc GetAcl(GetAclRequest) returns (Acl) {\n        option (google.api.http).get = \"/v2/acls/{resource=**}:getAcl\";\n      }\n      ...\n    }",
+      "id": "Mixin",
+      "properties": {
+        "name": {
+          "description": "The fully qualified name of the interface which is included.",
+          "type": "string"
+        },
+        "root": {
+          "description": "If non-empty specifies a path under which inherited HTTP paths\nare rooted.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "MonitoredResourceDescriptor": {
+      "description": "An object that describes the schema of a MonitoredResource object using a\ntype name and a set of labels.  For example, the monitored resource\ndescriptor for Google Compute Engine VM instances has a type of\n`\"gce_instance\"` and specifies the use of the labels `\"instance_id\"` and\n`\"zone\"` to identify particular VM instances.\n\nDifferent APIs can support different monitored resource types. APIs generally\nprovide a `list` method that returns the monitored resource descriptors used\nby the API.",
+      "id": "MonitoredResourceDescriptor",
+      "properties": {
+        "description": {
+          "description": "Optional. A detailed description of the monitored resource type that might\nbe used in documentation.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Optional. A concise name for the monitored resource type that might be\ndisplayed in user interfaces. It should be a Title Cased Noun Phrase,\nwithout any article or other determiners. For example,\n`\"Google Cloud SQL Database\"`.",
+          "type": "string"
+        },
+        "labels": {
+          "description": "Required. A set of labels used to describe instances of this monitored\nresource type. For example, an individual Google Cloud SQL database is\nidentified by values for the labels `\"database_id\"` and `\"zone\"`.",
+          "items": {
+            "$ref": "LabelDescriptor"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Optional. The resource name of the monitored resource descriptor:\n`\"projects/{project_id}/monitoredResourceDescriptors/{type}\"` where\n{type} is the value of the `type` field in this object and\n{project_id} is a project ID that provides API-specific context for\naccessing the type.  APIs that do not use project information can use the\nresource name format `\"monitoredResourceDescriptors/{type}\"`.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Required. The monitored resource type. For example, the type\n`\"cloudsql_database\"` represents databases in Google Cloud SQL.\nThe maximum length of this value is 256 characters.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Monitoring": {
+      "description": "Monitoring configuration of the service.\n\nThe example below shows how to configure monitored resources and metrics\nfor monitoring. In the example, a monitored resource and two metrics are\ndefined. The `library.googleapis.com/book/returned_count` metric is sent\nto both producer and consumer projects, whereas the\n`library.googleapis.com/book/overdue_count` metric is only sent to the\nconsumer project.\n\n    monitored_resources:\n    - type: library.googleapis.com/branch\n      labels:\n      - key: /city\n        description: The city where the library branch is located in.\n      - key: /name\n        description: The name of the branch.\n    metrics:\n    - name: library.googleapis.com/book/returned_count\n      metric_kind: DELTA\n      value_type: INT64\n      labels:\n      - key: /customer_id\n    - name: library.googleapis.com/book/overdue_count\n      metric_kind: GAUGE\n      value_type: INT64\n      labels:\n      - key: /customer_id\n    monitoring:\n      producer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        metrics:\n        - library.googleapis.com/book/returned_count\n      consumer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        metrics:\n        - library.googleapis.com/book/returned_count\n        - library.googleapis.com/book/overdue_count",
+      "id": "Monitoring",
+      "properties": {
+        "consumerDestinations": {
+          "description": "Monitoring configurations for sending metrics to the consumer project.\nThere can be multiple consumer destinations, each one must have a\ndifferent monitored resource type. A metric can be used in at most\none consumer destination.",
+          "items": {
+            "$ref": "MonitoringDestination"
+          },
+          "type": "array"
+        },
+        "producerDestinations": {
+          "description": "Monitoring configurations for sending metrics to the producer project.\nThere can be multiple producer destinations, each one must have a\ndifferent monitored resource type. A metric can be used in at most\none producer destination.",
+          "items": {
+            "$ref": "MonitoringDestination"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "MonitoringDestination": {
+      "description": "Configuration of a specific monitoring destination (the producer project\nor the consumer project).",
+      "id": "MonitoringDestination",
+      "properties": {
+        "metrics": {
+          "description": "Names of the metrics to report to this monitoring destination.\nEach name must be defined in Service.metrics section.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "monitoredResource": {
+          "description": "The monitored resource type. The type must be defined in\nService.monitored_resources section.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "OAuthRequirements": {
+      "description": "OAuth scopes are a way to define data and permissions on data. For example,\nthere are scopes defined for \"Read-only access to Google Calendar\" and\n\"Access to Cloud Platform\". Users can consent to a scope for an application,\ngiving it permission to access that data on their behalf.\n\nOAuth scope specifications should be fairly coarse grained; a user will need\nto see and understand the text description of what your scope means.\n\nIn most cases: use one or at most two OAuth scopes for an entire family of\nproducts. If your product has multiple APIs, you should probably be sharing\nthe OAuth scope across all of those APIs.\n\nWhen you need finer grained OAuth consent screens: talk with your product\nmanagement about how developers will use them in practice.\n\nPlease note that even though each of the canonical scopes is enough for a\nrequest to be accepted and passed to the backend, a request can still fail\ndue to the backend requiring additional scopes or permissions.",
+      "id": "OAuthRequirements",
+      "properties": {
+        "canonicalScopes": {
+          "description": "The list of publicly documented OAuth scopes that are allowed access. An\nOAuth token containing any of these scopes will be accepted.\n\nExample:\n\n     canonical_scopes: https://www.googleapis.com/auth/calendar,\n                       https://www.googleapis.com/auth/calendar.read",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Operation": {
+      "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
+      "id": "Operation",
+      "properties": {
+        "done": {
+          "description": "If the value is `false`, it means the operation is still in progress.\nIf `true`, the operation is completed, and either `error` or `response` is\navailable.",
+          "type": "boolean"
+        },
+        "error": {
+          "$ref": "Status",
+          "description": "The error result of the operation in case of failure or cancellation."
+        },
+        "metadata": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "description": "Service-specific metadata associated with the operation.  It typically\ncontains progress information and common metadata such as create time.\nSome services might not provide such metadata.  Any method that returns a\nlong-running operation should document the metadata type, if any.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The server-assigned name, which is only unique within the same service that\noriginally returns it. If you use the default HTTP mapping, the\n`name` should have the format of `operations/some/unique/name`.",
+          "type": "string"
+        },
+        "response": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "description": "The normal response of the operation in case of success.  If the original\nmethod returns no data on success, such as `Delete`, the response is\n`google.protobuf.Empty`.  If the original method is standard\n`Get`/`Create`/`Update`, the response should be the resource.  For other\nmethods, the response should have the type `XxxResponse`, where `Xxx`\nis the original method name.  For example, if the original method name\nis `TakeSnapshot()`, the inferred response type is\n`TakeSnapshotResponse`.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Option": {
+      "description": "A protocol buffer option, which can be attached to a message, field,\nenumeration, etc.",
+      "id": "Option",
+      "properties": {
+        "name": {
+          "description": "The option's name. For protobuf built-in options (options defined in\ndescriptor.proto), this is the short name. For example, `\"map_entry\"`.\nFor custom options, it should be the fully-qualified name. For example,\n`\"google.api.http\"`.",
+          "type": "string"
+        },
+        "value": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "description": "The option's value packed in an Any message. If the value is a primitive,\nthe corresponding wrapper type defined in google/protobuf/wrappers.proto\nshould be used. If the value is an enum, it should be stored as an int32\nvalue using the google.protobuf.Int32Value type.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Page": {
+      "description": "Represents a documentation page. A page can contain subpages to represent\nnested documentation set structure.",
+      "id": "Page",
+      "properties": {
+        "content": {
+          "description": "The Markdown content of the page. You can use \u003ccode\u003e\u0026#40;== include {path} ==\u0026#41;\u003c/code\u003e\nto include content from a Markdown file.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the page. It will be used as an identity of the page to\ngenerate URI of the page, text of the link to this page in navigation,\netc. The full page name (start from the root page name to this page\nconcatenated with `.`) can be used as reference to the page in your\ndocumentation. For example:\n\u003cpre\u003e\u003ccode\u003epages:\n- name: Tutorial\n  content: \u0026#40;== include tutorial.md ==\u0026#41;\n  subpages:\n  - name: Java\n    content: \u0026#40;== include tutorial_java.md ==\u0026#41;\n\u003c/code\u003e\u003c/pre\u003e\nYou can reference `Java` page using Markdown reference link syntax:\n`Java`.",
+          "type": "string"
+        },
+        "subpages": {
+          "description": "Subpages of this page. The order of subpages specified here will be\nhonored in the generated docset.",
+          "items": {
+            "$ref": "Page"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Quota": {
+      "description": "Quota configuration helps to achieve fairness and budgeting in service\nusage.\n\nThe quota configuration works this way:\n- The service configuration defines a set of metrics.\n- For API calls, the quota.metric_rules maps methods to metrics with\n  corresponding costs.\n- The quota.limits defines limits on the metrics, which will be used for\n  quota checks at runtime.\n\nAn example quota configuration in yaml format:\n\n   quota:\n     limits:\n\n     - name: apiWriteQpsPerProject\n       metric: library.googleapis.com/write_calls\n       unit: \"1/min/{project}\"  # rate limit for consumer projects\n       values:\n         STANDARD: 10000\n\n\n     # The metric rules bind all methods to the read_calls metric,\n     # except for the UpdateBook and DeleteBook methods. These two methods\n     # are mapped to the write_calls metric, with the UpdateBook method\n     # consuming at twice rate as the DeleteBook method.\n     metric_rules:\n     - selector: \"*\"\n       metric_costs:\n         library.googleapis.com/read_calls: 1\n     - selector: google.example.library.v1.LibraryService.UpdateBook\n       metric_costs:\n         library.googleapis.com/write_calls: 2\n     - selector: google.example.library.v1.LibraryService.DeleteBook\n       metric_costs:\n         library.googleapis.com/write_calls: 1\n\n Corresponding Metric definition:\n\n     metrics:\n     - name: library.googleapis.com/read_calls\n       display_name: Read requests\n       metric_kind: DELTA\n       value_type: INT64\n\n     - name: library.googleapis.com/write_calls\n       display_name: Write requests\n       metric_kind: DELTA\n       value_type: INT64",
+      "id": "Quota",
+      "properties": {
+        "limits": {
+          "description": "List of `QuotaLimit` definitions for the service.",
+          "items": {
+            "$ref": "QuotaLimit"
+          },
+          "type": "array"
+        },
+        "metricRules": {
+          "description": "List of `MetricRule` definitions, each one mapping a selected method to one\nor more metrics.",
+          "items": {
+            "$ref": "MetricRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "QuotaLimit": {
+      "description": "`QuotaLimit` defines a specific limit that applies over a specified duration\nfor a limit type. There can be at most one limit for a duration and limit\ntype combination defined within a `QuotaGroup`.",
+      "id": "QuotaLimit",
+      "properties": {
+        "defaultLimit": {
+          "description": "Default number of tokens that can be consumed during the specified\nduration. This is the number of tokens assigned when a client\napplication developer activates the service for his/her project.\n\nSpecifying a value of 0 will block all requests. This can be used if you\nare provisioning quota to selected consumers and blocking others.\nSimilarly, a value of -1 will indicate an unlimited quota. No other\nnegative values are allowed.\n\nUsed by group-based quotas only.",
+          "format": "int64",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional. User-visible, extended description for this quota limit.\nShould be used only when more context is needed to understand this limit\nthan provided by the limit's display name (see: `display_name`).",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "User-visible display name for this limit.\nOptional. If not set, the UI will provide a default display name based on\nthe quota configuration. This field can be used to override the default\ndisplay name generated from the configuration.",
+          "type": "string"
+        },
+        "duration": {
+          "description": "Duration of this limit in textual notation. Example: \"100s\", \"24h\", \"1d\".\nFor duration longer than a day, only multiple of days is supported. We\nsupport only \"100s\" and \"1d\" for now. Additional support will be added in\nthe future. \"0\" indicates indefinite duration.\n\nUsed by group-based quotas only.",
+          "type": "string"
+        },
+        "freeTier": {
+          "description": "Free tier value displayed in the Developers Console for this limit.\nThe free tier is the number of tokens that will be subtracted from the\nbilled amount when billing is enabled.\nThis field can only be set on a limit with duration \"1d\", in a billable\ngroup; it is invalid on any other limit. If this field is not set, it\ndefaults to 0, indicating that there is no free tier for this service.\n\nUsed by group-based quotas only.",
+          "format": "int64",
+          "type": "string"
+        },
+        "maxLimit": {
+          "description": "Maximum number of tokens that can be consumed during the specified\nduration. Client application developers can override the default limit up\nto this maximum. If specified, this value cannot be set to a value less\nthan the default limit. If not specified, it is set to the default limit.\n\nTo allow clients to apply overrides with no upper bound, set this to -1,\nindicating unlimited maximum quota.\n\nUsed by group-based quotas only.",
+          "format": "int64",
+          "type": "string"
+        },
+        "metric": {
+          "description": "The name of the metric this quota limit applies to. The quota limits with\nthe same metric will be checked together during runtime. The metric must be\ndefined within the service config.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the quota limit.\n\nThe name must be provided, and it must be unique within the service. The\nname can only include alphanumeric characters as well as '-'.\n\nThe maximum length of the limit name is 64 characters.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "Specify the unit of the quota limit. It uses the same syntax as\nMetric.unit. The supported unit kinds are determined by the quota\nbackend system.\n\nHere are some examples:\n* \"1/min/{project}\" for quota per minute per project.\n\nNote: the order of unit components is insignificant.\nThe \"1\" at the beginning is required to follow the metric unit syntax.",
+          "type": "string"
+        },
+        "values": {
+          "additionalProperties": {
+            "format": "int64",
+            "type": "string"
+          },
+          "description": "Tiered limit values. You must specify this as a key:value pair, with an\ninteger value that is the maximum number of requests allowed for the\nspecified unit. Currently only STANDARD is supported.",
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "Service": {
+      "description": "`Service` is the root object of Google service configuration schema. It\ndescribes basic information about a service, such as the name and the\ntitle, and delegates other aspects to sub-sections. Each sub-section is\neither a proto message or a repeated proto message that configures a\nspecific aspect, such as auth. See each proto message definition for details.\n\nExample:\n\n    type: google.api.Service\n    config_version: 3\n    name: calendar.googleapis.com\n    title: Google Calendar API\n    apis:\n    - name: google.calendar.v3.Calendar\n    authentication:\n      providers:\n      - id: google_calendar_auth\n        jwks_uri: https://www.googleapis.com/oauth2/v1/certs\n        issuer: https://securetoken.google.com\n      rules:\n      - selector: \"*\"\n        requirements:\n          provider_id: google_calendar_auth",
+      "id": "Service",
+      "properties": {
+        "apis": {
+          "description": "A list of API interfaces exported by this service. Only the `name` field\nof the google.protobuf.Api needs to be provided by the configuration\nauthor, as the remaining fields will be derived from the IDL during the\nnormalization process. It is an error to specify an API interface here\nwhich cannot be resolved against the associated IDL files.",
+          "items": {
+            "$ref": "Api"
+          },
+          "type": "array"
+        },
+        "authentication": {
+          "$ref": "Authentication",
+          "description": "Auth configuration."
+        },
+        "backend": {
+          "$ref": "Backend",
+          "description": "API backend configuration."
+        },
+        "billing": {
+          "$ref": "Billing",
+          "description": "Billing configuration."
+        },
+        "configVersion": {
+          "description": "The semantic version of the service configuration. The config version\naffects the interpretation of the service configuration. For example,\ncertain features are enabled by default for certain config versions.\nThe latest config version is `3`.",
+          "format": "uint32",
+          "type": "integer"
+        },
+        "context": {
+          "$ref": "Context",
+          "description": "Context configuration."
+        },
+        "control": {
+          "$ref": "Control",
+          "description": "Configuration for the service control plane."
+        },
+        "customError": {
+          "$ref": "CustomError",
+          "description": "Custom error configuration."
+        },
+        "documentation": {
+          "$ref": "Documentation",
+          "description": "Additional API documentation."
+        },
+        "endpoints": {
+          "description": "Configuration for network endpoints.  If this is empty, then an endpoint\nwith the same name as the service is automatically generated to service all\ndefined APIs.",
+          "items": {
+            "$ref": "Endpoint"
+          },
+          "type": "array"
+        },
+        "enums": {
+          "description": "A list of all enum types included in this API service.  Enums\nreferenced directly or indirectly by the `apis` are automatically\nincluded.  Enums which are not referenced but shall be included\nshould be listed here by name. Example:\n\n    enums:\n    - name: google.someapi.v1.SomeEnum",
+          "items": {
+            "$ref": "Enum"
+          },
+          "type": "array"
+        },
+        "experimental": {
+          "$ref": "Experimental",
+          "description": "Experimental configuration."
+        },
+        "http": {
+          "$ref": "Http",
+          "description": "HTTP configuration."
+        },
+        "id": {
+          "description": "A unique ID for a specific instance of this message, typically assigned\nby the client for tracking purpose. If empty, the server may choose to\ngenerate one instead. Must be no longer than 60 characters.",
+          "type": "string"
+        },
+        "logging": {
+          "$ref": "Logging",
+          "description": "Logging configuration."
+        },
+        "logs": {
+          "description": "Defines the logs used by this service.",
+          "items": {
+            "$ref": "LogDescriptor"
+          },
+          "type": "array"
+        },
+        "metrics": {
+          "description": "Defines the metrics used by this service.",
+          "items": {
+            "$ref": "MetricDescriptor"
+          },
+          "type": "array"
+        },
+        "monitoredResources": {
+          "description": "Defines the monitored resources used by this service. This is required\nby the Service.monitoring and Service.logging configurations.",
+          "items": {
+            "$ref": "MonitoredResourceDescriptor"
+          },
+          "type": "array"
+        },
+        "monitoring": {
+          "$ref": "Monitoring",
+          "description": "Monitoring configuration."
+        },
+        "name": {
+          "description": "The DNS address at which this service is available,\ne.g. `calendar.googleapis.com`.",
+          "type": "string"
+        },
+        "producerProjectId": {
+          "description": "The Google project that owns this service.",
+          "type": "string"
+        },
+        "quota": {
+          "$ref": "Quota",
+          "description": "Quota configuration."
+        },
+        "sourceInfo": {
+          "$ref": "SourceInfo",
+          "description": "Output only. The source information for this configuration if available."
+        },
+        "systemParameters": {
+          "$ref": "SystemParameters",
+          "description": "System parameter configuration."
+        },
+        "systemTypes": {
+          "description": "A list of all proto message types included in this API service.\nIt serves similar purpose as [google.api.Service.types], except that\nthese types are not needed by user-defined APIs. Therefore, they will not\nshow up in the generated discovery doc. This field should only be used\nto define system APIs in ESF.",
+          "items": {
+            "$ref": "Type"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "The product title for this service.",
+          "type": "string"
+        },
+        "types": {
+          "description": "A list of all proto message types included in this API service.\nTypes referenced directly or indirectly by the `apis` are\nautomatically included.  Messages which are not referenced but\nshall be included, such as types used by the `google.protobuf.Any` type,\nshould be listed here by name. Example:\n\n    types:\n    - name: google.protobuf.Int32",
+          "items": {
+            "$ref": "Type"
+          },
+          "type": "array"
+        },
+        "usage": {
+          "$ref": "Usage",
+          "description": "Configuration controlling usage of this service."
+        }
+      },
+      "type": "object"
+    },
+    "SourceContext": {
+      "description": "`SourceContext` represents information about the source of a\nprotobuf element, like the file in which it is defined.",
+      "id": "SourceContext",
+      "properties": {
+        "fileName": {
+          "description": "The path-qualified name of the .proto file that contained the associated\nprotobuf element.  For example: `\"google/protobuf/source_context.proto\"`.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SourceInfo": {
+      "description": "Source information used to create a Service Config",
+      "id": "SourceInfo",
+      "properties": {
+        "sourceFiles": {
+          "description": "All files used during config generation.",
+          "items": {
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            },
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Status": {
+      "description": "The `Status` type defines a logical error model that is suitable for different\nprogramming environments, including REST APIs and RPC APIs. It is used by\n[gRPC](https://github.com/grpc). The error model is designed to be:\n\n- Simple to use and understand for most users\n- Flexible enough to meet unexpected needs\n\n# Overview\n\nThe `Status` message contains three pieces of data: error code, error message,\nand error details. The error code should be an enum value of\ngoogle.rpc.Code, but it may accept additional error codes if needed.  The\nerror message should be a developer-facing English message that helps\ndevelopers *understand* and *resolve* the error. If a localized user-facing\nerror message is needed, put the localized message in the error details or\nlocalize it in the client. The optional error details may contain arbitrary\ninformation about the error. There is a predefined set of error detail types\nin the package `google.rpc` that can be used for common error conditions.\n\n# Language mapping\n\nThe `Status` message is the logical representation of the error model, but it\nis not necessarily the actual wire format. When the `Status` message is\nexposed in different client libraries and different wire protocols, it can be\nmapped differently. For example, it will likely be mapped to some exceptions\nin Java, but more likely mapped to some error codes in C.\n\n# Other uses\n\nThe error model and the `Status` message can be used in a variety of\nenvironments, either with or without APIs, to provide a\nconsistent developer experience across different environments.\n\nExample uses of this error model include:\n\n- Partial errors. If a service needs to return partial errors to the client,\n    it may embed the `Status` in the normal response to indicate the partial\n    errors.\n\n- Workflow errors. A typical workflow has multiple steps. Each step may\n    have a `Status` message for error reporting.\n\n- Batch operations. If a client uses batch request and batch response, the\n    `Status` message should be used directly inside batch response, one for\n    each error sub-response.\n\n- Asynchronous operations. If an API call embeds asynchronous operation\n    results in its response, the status of those operations should be\n    represented directly using the `Status` message.\n\n- Logging. If some API errors are stored in logs, the message `Status` could\n    be used directly after any stripping needed for security/privacy reasons.",
+      "id": "Status",
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "details": {
+          "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use.",
+          "items": {
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            },
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Subnetwork": {
+      "description": "Message returning the created service subnetwork.",
+      "id": "Subnetwork",
+      "properties": {
+        "ipCidrRange": {
+          "description": "Subnetwork CIDR range in \"10.x.x.x/y\" format.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Subnetwork name.\nSee https://cloud.google.com/compute/docs/vpc/",
+          "type": "string"
+        },
+        "network": {
+          "description": "Shared VPC host project network peered with consumer network.\nFor example: projects/1234321/global/networks/host-network",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SystemParameter": {
+      "description": "Define a parameter's name and location. The parameter may be passed as either\nan HTTP header or a URL query parameter, and if both are passed the behavior\nis implementation-dependent.",
+      "id": "SystemParameter",
+      "properties": {
+        "httpHeader": {
+          "description": "Define the HTTP header name to use for the parameter. It is case\ninsensitive.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Define the name of the parameter, such as \"api_key\" . It is case sensitive.",
+          "type": "string"
+        },
+        "urlQueryParameter": {
+          "description": "Define the URL query parameter name to use for the parameter. It is case\nsensitive.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SystemParameterRule": {
+      "description": "Define a system parameter rule mapping system parameter definitions to\nmethods.",
+      "id": "SystemParameterRule",
+      "properties": {
+        "parameters": {
+          "description": "Define parameters. Multiple names may be defined for a parameter.\nFor a given method call, only one of them should be used. If multiple\nnames are used the behavior is implementation-dependent.\nIf none of the specified names are present the behavior is\nparameter-dependent.",
+          "items": {
+            "$ref": "SystemParameter"
+          },
+          "type": "array"
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies. Use '*' to indicate all\nmethods in all APIs.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SystemParameters": {
+      "description": "### System parameter configuration\n\nA system parameter is a special kind of parameter defined by the API\nsystem, not by an individual API. It is typically mapped to an HTTP header\nand/or a URL query parameter. This configuration specifies which methods\nchange the names of the system parameters.",
+      "id": "SystemParameters",
+      "properties": {
+        "rules": {
+          "description": "Define system parameters.\n\nThe parameters defined here will override the default parameters\nimplemented by the system. If this field is missing from the service\nconfig, default system parameters will be used. Default system parameters\nand names is implementation-dependent.\n\nExample: define api key for all methods\n\n    system_parameters\n      rules:\n        - selector: \"*\"\n          parameters:\n            - name: api_key\n              url_query_parameter: api_key\n\n\nExample: define 2 api key names for a specific method.\n\n    system_parameters\n      rules:\n        - selector: \"/ListShelves\"\n          parameters:\n            - name: api_key\n              http_header: Api-Key1\n            - name: api_key\n              http_header: Api-Key2\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "items": {
+            "$ref": "SystemParameterRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Type": {
+      "description": "A protocol buffer message type.",
+      "id": "Type",
+      "properties": {
+        "fields": {
+          "description": "The list of fields.",
+          "items": {
+            "$ref": "Field"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "The fully qualified message name.",
+          "type": "string"
+        },
+        "oneofs": {
+          "description": "The list of types appearing in `oneof` definitions in this type.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "options": {
+          "description": "The protocol buffer options.",
+          "items": {
+            "$ref": "Option"
+          },
+          "type": "array"
+        },
+        "sourceContext": {
+          "$ref": "SourceContext",
+          "description": "The source context."
+        },
+        "syntax": {
+          "description": "The source syntax.",
+          "enum": [
+            "SYNTAX_PROTO2",
+            "SYNTAX_PROTO3"
+          ],
+          "enumDescriptions": [
+            "Syntax `proto2`.",
+            "Syntax `proto3`."
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Usage": {
+      "description": "Configuration controlling usage of a service.",
+      "id": "Usage",
+      "properties": {
+        "producerNotificationChannel": {
+          "description": "The full resource name of a channel used for sending notifications to the\nservice producer.\n\nGoogle Service Management currently only supports\n[Google Cloud Pub/Sub](https://cloud.google.com/pubsub) as a notification\nchannel. To use Google Cloud Pub/Sub as the channel, this must be the name\nof a Cloud Pub/Sub topic that uses the Cloud Pub/Sub topic name format\ndocumented in https://cloud.google.com/pubsub/docs/overview.",
+          "type": "string"
+        },
+        "requirements": {
+          "description": "Requirements that must be satisfied before a consumer project can use the\nservice. Each requirement is of the form \u003cservice.name\u003e/\u003crequirement-id\u003e;\nfor example 'serviceusage.googleapis.com/billing-enabled'.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rules": {
+          "description": "A list of usage rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "items": {
+            "$ref": "UsageRule"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "UsageRule": {
+      "description": "Usage configuration rules for the service.\n\nNOTE: Under development.\n\n\nUse this rule to configure unregistered calls for the service. Unregistered\ncalls are calls that do not contain consumer project identity.\n(Example: calls that do not contain an API key).\nBy default, API methods do not allow unregistered calls, and each method call\nmust be identified by a consumer project identity. Use this rule to\nallow/disallow unregistered calls.\n\nExample of an API that wants to allow unregistered calls for entire service.\n\n    usage:\n      rules:\n      - selector: \"*\"\n        allow_unregistered_calls: true\n\nExample of a method that wants to allow unregistered calls.\n\n    usage:\n      rules:\n      - selector: \"google.example.library.v1.LibraryService.CreateBook\"\n        allow_unregistered_calls: true",
+      "id": "UsageRule",
+      "properties": {
+        "allowUnregisteredCalls": {
+          "description": "If true, the selected method allows unregistered calls, e.g. calls\nthat don't identify any user or application.",
+          "type": "boolean"
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies. Use '*' to indicate all\nmethods in all APIs.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        },
+        "skipServiceControl": {
+          "description": "If true, the selected method should skip service control and the control\nplane features, such as quota and billing, will not be available.\nThis flag is used by Google Cloud Endpoints to bypass checks for internal\nmethods, such as service health check methods.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "servicePath": "",
+  "title": "Service Networking API",
+  "version": "v1beta",
+  "version_module": true
+}

--- a/vendor/google.golang.org/api/servicenetworking/v1beta/servicenetworking-gen.go
+++ b/vendor/google.golang.org/api/servicenetworking/v1beta/servicenetworking-gen.go
@@ -1,0 +1,4806 @@
+// Package servicenetworking provides access to the Service Networking API.
+//
+// See https://cloud.google.com/service-infrastructure/docs/service-networking/getting-started
+//
+// Usage example:
+//
+//   import "google.golang.org/api/servicenetworking/v1beta"
+//   ...
+//   servicenetworkingService, err := servicenetworking.New(oauthHttpClient)
+package servicenetworking // import "google.golang.org/api/servicenetworking/v1beta"
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	context "golang.org/x/net/context"
+	ctxhttp "golang.org/x/net/context/ctxhttp"
+	gensupport "google.golang.org/api/gensupport"
+	googleapi "google.golang.org/api/googleapi"
+)
+
+// Always reference these packages, just in case the auto-generated code
+// below doesn't.
+var _ = bytes.NewBuffer
+var _ = strconv.Itoa
+var _ = fmt.Sprintf
+var _ = json.NewDecoder
+var _ = io.Copy
+var _ = url.Parse
+var _ = gensupport.MarshalJSON
+var _ = googleapi.Version
+var _ = errors.New
+var _ = strings.Replace
+var _ = context.Canceled
+var _ = ctxhttp.Do
+
+const apiId = "servicenetworking:v1beta"
+const apiName = "servicenetworking"
+const apiVersion = "v1beta"
+const basePath = "https://servicenetworking.googleapis.com/"
+
+// OAuth2 scopes used by this API.
+const (
+	// View and manage your data across Google Cloud Platform services
+	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+	// Manage your Google API service configuration
+	ServiceManagementScope = "https://www.googleapis.com/auth/service.management"
+)
+
+func New(client *http.Client) (*APIService, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+	s := &APIService{client: client, BasePath: basePath}
+	s.Operations = NewOperationsService(s)
+	s.Services = NewServicesService(s)
+	return s, nil
+}
+
+type APIService struct {
+	client    *http.Client
+	BasePath  string // API endpoint base URL
+	UserAgent string // optional additional User-Agent fragment
+
+	Operations *OperationsService
+
+	Services *ServicesService
+}
+
+func (s *APIService) userAgent() string {
+	if s.UserAgent == "" {
+		return googleapi.UserAgent
+	}
+	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func NewOperationsService(s *APIService) *OperationsService {
+	rs := &OperationsService{s: s}
+	return rs
+}
+
+type OperationsService struct {
+	s *APIService
+}
+
+func NewServicesService(s *APIService) *ServicesService {
+	rs := &ServicesService{s: s}
+	rs.Connections = NewServicesConnectionsService(s)
+	return rs
+}
+
+type ServicesService struct {
+	s *APIService
+
+	Connections *ServicesConnectionsService
+}
+
+func NewServicesConnectionsService(s *APIService) *ServicesConnectionsService {
+	rs := &ServicesConnectionsService{s: s}
+	return rs
+}
+
+type ServicesConnectionsService struct {
+	s *APIService
+}
+
+// AddSubnetworkRequest: Request to create a subnetwork in a previously
+// peered service network.
+type AddSubnetworkRequest struct {
+	// Consumer: Required. Resource representing service consumer. It may be
+	// different from
+	// the project number in consumer network parameter in case of that
+	// network
+	// being a shared VPC network. In that case, Service Networking will
+	// validate
+	// that this resource belongs to that shared VPC.
+	// For example 'projects/123456'.
+	Consumer string `json:"consumer,omitempty"`
+
+	// ConsumerNetwork: Required. Network name in the consumer project.
+	// This network must have been
+	// already peered with a shared VPC network using
+	// CreateConnection
+	// method.
+	// Must be in a form
+	// 'projects/{project}/global/networks/{network}'.
+	// {project} is a project number, as in '12345'
+	// {network} is network name.
+	ConsumerNetwork string `json:"consumerNetwork,omitempty"`
+
+	// Description: Optional. Description of the subnetwork.
+	Description string `json:"description,omitempty"`
+
+	// IpPrefixLength: Required. The prefix length of the IP range.
+	// Use usual CIDR range notation.
+	// For example, '30' to provision subnet with x.x.x.x/30 CIDR
+	// range.
+	// Actual range will be determined using allocated range for the
+	// consumer
+	// peered network and returned in the result.
+	IpPrefixLength int64 `json:"ipPrefixLength,omitempty"`
+
+	// Region: Required. Cloud
+	// [region](/compute/docs/reference/rest/v1/regions) for the
+	// new
+	// subnetwork.
+	Region string `json:"region,omitempty"`
+
+	// RequestedAddress: Optional. The starting address of a range. The
+	// address must be a valid
+	// IPv4 address in the x.x.x.x format. This value combined with the IP
+	// prefix
+	// range is the CIDR range for the subnet. The range must be within
+	// the
+	// allocated range that is assigned to the private connection. If the
+	// CIDR
+	// range isn't available, the call fails.
+	RequestedAddress string `json:"requestedAddress,omitempty"`
+
+	// Subnetwork: Required. Name for the new subnetwork.
+	// Must be a legal
+	// [subnetwork](compute/docs/reference/rest/v1/subnetworks)
+	// name.
+	Subnetwork string `json:"subnetwork,omitempty"`
+
+	// SubnetworkUsers: Optional. List of members that will be granted
+	// 'compute.networkUser' role
+	// on the newly added subnetwork.
+	SubnetworkUsers []string `json:"subnetworkUsers,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Consumer") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Consumer") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AddSubnetworkRequest) MarshalJSON() ([]byte, error) {
+	type NoMethod AddSubnetworkRequest
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Api: Api is a light-weight descriptor for an API
+// Interface.
+//
+// Interfaces are also described as "protocol buffer services" in some
+// contexts,
+// such as by the "service" keyword in a .proto file, but they are
+// different
+// from API Services, which represent a concrete implementation of an
+// interface
+// as opposed to simply a description of methods and bindings. They are
+// also
+// sometimes simply referred to as "APIs" in other contexts, such as the
+// name of
+// this message itself. See
+// https://cloud.google.com/apis/design/glossary for
+// detailed terminology.
+type Api struct {
+	// Methods: The methods of this interface, in unspecified order.
+	Methods []*Method `json:"methods,omitempty"`
+
+	// Mixins: Included interfaces. See Mixin.
+	Mixins []*Mixin `json:"mixins,omitempty"`
+
+	// Name: The fully qualified name of this interface, including package
+	// name
+	// followed by the interface's simple name.
+	Name string `json:"name,omitempty"`
+
+	// Options: Any metadata attached to the interface.
+	Options []*Option `json:"options,omitempty"`
+
+	// SourceContext: Source context for the protocol buffer service
+	// represented by this
+	// message.
+	SourceContext *SourceContext `json:"sourceContext,omitempty"`
+
+	// Syntax: The source syntax of the service.
+	//
+	// Possible values:
+	//   "SYNTAX_PROTO2" - Syntax `proto2`.
+	//   "SYNTAX_PROTO3" - Syntax `proto3`.
+	Syntax string `json:"syntax,omitempty"`
+
+	// Version: A version string for this interface. If specified, must have
+	// the form
+	// `major-version.minor-version`, as in `1.10`. If the minor version
+	// is
+	// omitted, it defaults to zero. If the entire version field is empty,
+	// the
+	// major version is derived from the package name, as outlined below. If
+	// the
+	// field is not empty, the version in the package name will be verified
+	// to be
+	// consistent with what is provided here.
+	//
+	// The versioning schema uses [semantic
+	// versioning](http://semver.org) where the major version
+	// number
+	// indicates a breaking change and the minor version an
+	// additive,
+	// non-breaking change. Both version numbers are signals to users
+	// what to expect from different versions, and should be
+	// carefully
+	// chosen based on the product plan.
+	//
+	// The major version is also reflected in the package name of
+	// the
+	// interface, which must end in `v<major-version>`, as
+	// in
+	// `google.feature.v1`. For major versions 0 and 1, the suffix can
+	// be omitted. Zero major versions must only be used for
+	// experimental, non-GA interfaces.
+	//
+	Version string `json:"version,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Methods") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Methods") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Api) MarshalJSON() ([]byte, error) {
+	type NoMethod Api
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuthProvider: Configuration for an anthentication provider, including
+// support for
+// [JSON Web Token
+// (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32)
+// .
+type AuthProvider struct {
+	// Audiences: The list of
+	// JWT
+	// [audiences](https://tools.ietf.org/html/draft-ietf-oauth-json-web-
+	// token-32#section-4.1.3).
+	// that are allowed to access. A JWT containing any of these audiences
+	// will
+	// be accepted. When this setting is absent, only JWTs with
+	// audience
+	// "https://Service_name/API_name"
+	// will be accepted. For example, if no audiences are in the
+	// setting,
+	// LibraryService API will only accept JWTs with the following
+	// audience
+	// "https://library-example.googleapis.com/google.example.librar
+	// y.v1.LibraryService".
+	//
+	// Example:
+	//
+	//     audiences: bookstore_android.apps.googleusercontent.com,
+	//                bookstore_web.apps.googleusercontent.com
+	Audiences string `json:"audiences,omitempty"`
+
+	// AuthorizationUrl: Redirect URL if JWT token is required but no
+	// present or is expired.
+	// Implement authorizationUrl of securityDefinitions in OpenAPI spec.
+	AuthorizationUrl string `json:"authorizationUrl,omitempty"`
+
+	// Id: The unique identifier of the auth provider. It will be referred
+	// to by
+	// `AuthRequirement.provider_id`.
+	//
+	// Example: "bookstore_auth".
+	Id string `json:"id,omitempty"`
+
+	// Issuer: Identifies the principal that issued the JWT.
+	// See
+	// https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#sec
+	// tion-4.1.1
+	// Usually a URL or an email address.
+	//
+	// Example: https://securetoken.google.com
+	// Example: 1234567-compute@developer.gserviceaccount.com
+	Issuer string `json:"issuer,omitempty"`
+
+	// JwksUri: URL of the provider's public key set to validate signature
+	// of the JWT. See
+	// [OpenID
+	// Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#
+	// ProviderMetadata).
+	// Optional if the key set document:
+	//  - can be retrieved from
+	//    [OpenID
+	// Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html
+	//
+	//    of the issuer.
+	//  - can be inferred from the email domain of the issuer (e.g. a Google
+	// service account).
+	//
+	// Example: https://www.googleapis.com/oauth2/v1/certs
+	JwksUri string `json:"jwksUri,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Audiences") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Audiences") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuthProvider) MarshalJSON() ([]byte, error) {
+	type NoMethod AuthProvider
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuthRequirement: User-defined authentication requirements, including
+// support for
+// [JSON Web Token
+// (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32)
+// .
+type AuthRequirement struct {
+	// Audiences: NOTE: This will be deprecated soon, once
+	// AuthProvider.audiences is
+	// implemented and accepted in all the runtime components.
+	//
+	// The list of
+	// JWT
+	// [audiences](https://tools.ietf.org/html/draft-ietf-oauth-json-web-
+	// token-32#section-4.1.3).
+	// that are allowed to access. A JWT containing any of these audiences
+	// will
+	// be accepted. When this setting is absent, only JWTs with
+	// audience
+	// "https://Service_name/API_name"
+	// will be accepted. For example, if no audiences are in the
+	// setting,
+	// LibraryService API will only accept JWTs with the following
+	// audience
+	// "https://library-example.googleapis.com/google.example.librar
+	// y.v1.LibraryService".
+	//
+	// Example:
+	//
+	//     audiences: bookstore_android.apps.googleusercontent.com,
+	//                bookstore_web.apps.googleusercontent.com
+	Audiences string `json:"audiences,omitempty"`
+
+	// ProviderId: id from authentication provider.
+	//
+	// Example:
+	//
+	//     provider_id: bookstore_auth
+	ProviderId string `json:"providerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Audiences") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Audiences") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuthRequirement) MarshalJSON() ([]byte, error) {
+	type NoMethod AuthRequirement
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Authentication: `Authentication` defines the authentication
+// configuration for an API.
+//
+// Example for an API targeted for external use:
+//
+//     name: calendar.googleapis.com
+//     authentication:
+//       providers:
+//       - id: google_calendar_auth
+//         jwks_uri: https://www.googleapis.com/oauth2/v1/certs
+//         issuer: https://securetoken.google.com
+//       rules:
+//       - selector: "*"
+//         requirements:
+//           provider_id: google_calendar_auth
+type Authentication struct {
+	// Providers: Defines a set of authentication providers that a service
+	// supports.
+	Providers []*AuthProvider `json:"providers,omitempty"`
+
+	// Rules: A list of authentication rules that apply to individual API
+	// methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*AuthenticationRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Providers") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Providers") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Authentication) MarshalJSON() ([]byte, error) {
+	type NoMethod Authentication
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuthenticationRule: Authentication rules for the service.
+//
+// By default, if a method has any authentication requirements, every
+// request
+// must include a valid credential matching one of the
+// requirements.
+// It's an error to include more than one kind of credential in a
+// single
+// request.
+//
+// If a method doesn't have any auth requirements, request credentials
+// will be
+// ignored.
+type AuthenticationRule struct {
+	// AllowWithoutCredential: If true, the service accepts API keys without
+	// any other credential.
+	AllowWithoutCredential bool `json:"allowWithoutCredential,omitempty"`
+
+	// Oauth: The requirements for OAuth credentials.
+	Oauth *OAuthRequirements `json:"oauth,omitempty"`
+
+	// Requirements: Requirements for additional authentication providers.
+	Requirements []*AuthRequirement `json:"requirements,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "AllowWithoutCredential") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AllowWithoutCredential")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuthenticationRule) MarshalJSON() ([]byte, error) {
+	type NoMethod AuthenticationRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuthorizationConfig: Configuration of authorization.
+//
+// This section determines the authorization provider, if unspecified,
+// then no
+// authorization check will be done.
+//
+// Example:
+//
+//     experimental:
+//       authorization:
+//         provider: firebaserules.googleapis.com
+type AuthorizationConfig struct {
+	// Provider: The name of the authorization provider, such
+	// as
+	// firebaserules.googleapis.com.
+	Provider string `json:"provider,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Provider") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Provider") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuthorizationConfig) MarshalJSON() ([]byte, error) {
+	type NoMethod AuthorizationConfig
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Backend: `Backend` defines the backend configuration for a service.
+type Backend struct {
+	// Rules: A list of API backend rules that apply to individual API
+	// methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*BackendRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Backend) MarshalJSON() ([]byte, error) {
+	type NoMethod Backend
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// BackendRule: A backend rule provides configuration for an individual
+// API element.
+type BackendRule struct {
+	// Address: The address of the API backend.
+	Address string `json:"address,omitempty"`
+
+	// Deadline: The number of seconds to wait for a response from a
+	// request.  The default
+	// deadline for gRPC is infinite (no deadline) and HTTP requests is 5
+	// seconds.
+	Deadline float64 `json:"deadline,omitempty"`
+
+	// MinDeadline: Minimum deadline in seconds needed for this method.
+	// Calls having deadline
+	// value lower than this will be rejected.
+	MinDeadline float64 `json:"minDeadline,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Address") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Address") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *BackendRule) MarshalJSON() ([]byte, error) {
+	type NoMethod BackendRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *BackendRule) UnmarshalJSON(data []byte) error {
+	type NoMethod BackendRule
+	var s1 struct {
+		Deadline    gensupport.JSONFloat64 `json:"deadline"`
+		MinDeadline gensupport.JSONFloat64 `json:"minDeadline"`
+		*NoMethod
+	}
+	s1.NoMethod = (*NoMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Deadline = float64(s1.Deadline)
+	s.MinDeadline = float64(s1.MinDeadline)
+	return nil
+}
+
+// Billing: Billing related configuration of the service.
+//
+// The following example shows how to configure monitored resources and
+// metrics
+// for billing:
+//
+//     monitored_resources:
+//     - type: library.googleapis.com/branch
+//       labels:
+//       - key: /city
+//         description: The city where the library branch is located
+// in.
+//       - key: /name
+//         description: The name of the branch.
+//     metrics:
+//     - name: library.googleapis.com/book/borrowed_count
+//       metric_kind: DELTA
+//       value_type: INT64
+//     billing:
+//       consumer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         metrics:
+//         - library.googleapis.com/book/borrowed_count
+type Billing struct {
+	// ConsumerDestinations: Billing configurations for sending metrics to
+	// the consumer project.
+	// There can be multiple consumer destinations per service, each one
+	// must have
+	// a different monitored resource type. A metric can be used in at
+	// most
+	// one consumer destination.
+	ConsumerDestinations []*BillingDestination `json:"consumerDestinations,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "ConsumerDestinations") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConsumerDestinations") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Billing) MarshalJSON() ([]byte, error) {
+	type NoMethod Billing
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// BillingDestination: Configuration of a specific billing destination
+// (Currently only support
+// bill against consumer project).
+type BillingDestination struct {
+	// Metrics: Names of the metrics to report to this billing
+	// destination.
+	// Each name must be defined in Service.metrics section.
+	Metrics []string `json:"metrics,omitempty"`
+
+	// MonitoredResource: The monitored resource type. The type must be
+	// defined in
+	// Service.monitored_resources section.
+	MonitoredResource string `json:"monitoredResource,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Metrics") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Metrics") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *BillingDestination) MarshalJSON() ([]byte, error) {
+	type NoMethod BillingDestination
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Connection: Message returning the created service connection.
+type Connection struct {
+	// Network: Name of VPC network connected with service producer
+	// network.
+	// Must be in a form
+	// 'projects/{project}/global/networks/{network}'.
+	// {project} is a project number, as in '12345'
+	// {network} is a network name.
+	Network string `json:"network,omitempty"`
+
+	// Peering: Output only.
+	// Name of the peering connection that is created by the peering
+	// service.
+	Peering string `json:"peering,omitempty"`
+
+	// ReservedPeeringRanges: Named IP address range(s) of PEERING type
+	// allocated for this service
+	// provider.
+	// Note that invoking this method with a different range when connection
+	// is
+	// already established will not modify already provisioned
+	// service
+	// producer subnetworks.
+	ReservedPeeringRanges []string `json:"reservedPeeringRanges,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Network") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Network") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Connection) MarshalJSON() ([]byte, error) {
+	type NoMethod Connection
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Context: `Context` defines which contexts an API
+// requests.
+//
+// Example:
+//
+//     context:
+//       rules:
+//       - selector: "*"
+//         requested:
+//         - google.rpc.context.ProjectContext
+//         - google.rpc.context.OriginContext
+//
+// The above specifies that all methods in the API
+// request
+// `google.rpc.context.ProjectContext`
+// and
+// `google.rpc.context.OriginContext`.
+//
+// Available context types are defined in
+// package
+// `google.rpc.context`.
+//
+// This also provides mechanism to whitelist any protobuf message
+// extension that
+// can be sent in grpc metadata using
+// “x-goog-ext-<extension_id>-bin”
+// and
+// “x-goog-ext-<extension_id>-jspb” format. For example, list any
+// service
+// specific protobuf types that can appear in grpc metadata as follows
+// in your
+// yaml file:
+//
+// Example:
+//
+//     context:
+//       rules:
+//        - selector:
+// "google.example.library.v1.LibraryService.CreateBook"
+//          allowed_request_extensions:
+//          - google.foo.v1.NewExtension
+//          allowed_response_extensions:
+//          - google.foo.v1.NewExtension
+//
+// You can also specify extension ID instead of fully qualified
+// extension name
+// here.
+type Context struct {
+	// Rules: A list of RPC context rules that apply to individual API
+	// methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*ContextRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Context) MarshalJSON() ([]byte, error) {
+	type NoMethod Context
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ContextRule: A context rule provides information about the context
+// for an individual API
+// element.
+type ContextRule struct {
+	// AllowedRequestExtensions: A list of full type names or extension IDs
+	// of extensions allowed in grpc
+	// side channel from client to backend.
+	AllowedRequestExtensions []string `json:"allowedRequestExtensions,omitempty"`
+
+	// AllowedResponseExtensions: A list of full type names or extension IDs
+	// of extensions allowed in grpc
+	// side channel from backend to client.
+	AllowedResponseExtensions []string `json:"allowedResponseExtensions,omitempty"`
+
+	// Provided: A list of full type names of provided contexts.
+	Provided []string `json:"provided,omitempty"`
+
+	// Requested: A list of full type names of requested contexts.
+	Requested []string `json:"requested,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "AllowedRequestExtensions") to unconditionally include in API
+	// requests. By default, fields with empty values are omitted from API
+	// requests. However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AllowedRequestExtensions")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ContextRule) MarshalJSON() ([]byte, error) {
+	type NoMethod ContextRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Control: Selects and configures the service controller used by the
+// service.  The
+// service controller handles features like abuse, quota, billing,
+// logging,
+// monitoring, etc.
+type Control struct {
+	// Environment: The service control environment to use. If empty, no
+	// control plane
+	// feature (like quota and billing) will be enabled.
+	Environment string `json:"environment,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Environment") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Environment") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Control) MarshalJSON() ([]byte, error) {
+	type NoMethod Control
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CustomError: Customize service error responses.  For example, list
+// any service
+// specific protobuf types that can appear in error detail lists
+// of
+// error responses.
+//
+// Example:
+//
+//     custom_error:
+//       types:
+//       - google.foo.v1.CustomError
+//       - google.foo.v1.AnotherError
+type CustomError struct {
+	// Rules: The list of custom error rules that apply to individual API
+	// messages.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*CustomErrorRule `json:"rules,omitempty"`
+
+	// Types: The list of custom error detail types, e.g.
+	// 'google.foo.v1.CustomError'.
+	Types []string `json:"types,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CustomError) MarshalJSON() ([]byte, error) {
+	type NoMethod CustomError
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CustomErrorRule: A custom error rule.
+type CustomErrorRule struct {
+	// IsErrorType: Mark this message as possible payload in error response.
+	//  Otherwise,
+	// objects of this type will be filtered when they appear in error
+	// payload.
+	IsErrorType bool `json:"isErrorType,omitempty"`
+
+	// Selector: Selects messages to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "IsErrorType") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "IsErrorType") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CustomErrorRule) MarshalJSON() ([]byte, error) {
+	type NoMethod CustomErrorRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CustomHttpPattern: A custom pattern is used for defining custom HTTP
+// verb.
+type CustomHttpPattern struct {
+	// Kind: The name of this custom HTTP verb.
+	Kind string `json:"kind,omitempty"`
+
+	// Path: The path matched by this custom verb.
+	Path string `json:"path,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CustomHttpPattern) MarshalJSON() ([]byte, error) {
+	type NoMethod CustomHttpPattern
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Documentation: `Documentation` provides the information for
+// describing a service.
+//
+// Example:
+// <pre><code>documentation:
+//   summary: >
+//     The Google Calendar API gives access
+//     to most calendar features.
+//   pages:
+//   - name: Overview
+//     content: &#40;== include google/foo/overview.md ==&#41;
+//   - name: Tutorial
+//     content: &#40;== include google/foo/tutorial.md ==&#41;
+//     subpages;
+//     - name: Java
+//       content: &#40;== include google/foo/tutorial_java.md ==&#41;
+//   rules:
+//   - selector: google.calendar.Calendar.Get
+//     description: >
+//       ...
+//   - selector: google.calendar.Calendar.Put
+//     description: >
+//       ...
+// </code></pre>
+// Documentation is provided in markdown syntax. In addition to
+// standard markdown features, definition lists, tables and fenced
+// code blocks are supported. Section headers can be provided and
+// are
+// interpreted relative to the section nesting of the context where
+// a documentation fragment is embedded.
+//
+// Documentation from the IDL is merged with documentation defined
+// via the config at normalization time, where documentation provided
+// by config rules overrides IDL provided.
+//
+// A number of constructs specific to the API platform are supported
+// in documentation text.
+//
+// In order to reference a proto element, the following
+// notation can be
+// used:
+// <pre><code>&#91;fully.qualified.proto.name]&#91;]</code></pre>
+// T
+// o override the display text used for the link, this can be
+// used:
+// <pre><code>&#91;display
+// text]&#91;fully.qualified.proto.name]</code></pre>
+// Text can be excluded from doc using the following
+// notation:
+// <pre><code>&#40;-- internal comment --&#41;</code></pre>
+//
+// A few directives are available in documentation. Note that
+// directives must appear on a single line to be properly
+// identified. The `include` directive includes a markdown file from
+// an external source:
+// <pre><code>&#40;== include path/to/file ==&#41;</code></pre>
+// The `resource_for` directive marks a message to be the resource of
+// a collection in REST view. If it is not specified, tools attempt
+// to infer the resource from the operations in a
+// collection:
+// <pre><code>&#40;== resource_for v1.shelves.books
+// ==&#41;</code></pre>
+// The directive `suppress_warning` does not directly affect
+// documentation
+// and is documented together with service config validation.
+type Documentation struct {
+	// DocumentationRootUrl: The URL to the root of documentation.
+	DocumentationRootUrl string `json:"documentationRootUrl,omitempty"`
+
+	// Overview: Declares a single overview page. For
+	// example:
+	// <pre><code>documentation:
+	//   summary: ...
+	//   overview: &#40;== include overview.md ==&#41;
+	// </code></pre>
+	// This is a shortcut for the following declaration (using pages
+	// style):
+	// <pre><code>documentation:
+	//   summary: ...
+	//   pages:
+	//   - name: Overview
+	//     content: &#40;== include overview.md ==&#41;
+	// </code></pre>
+	// Note: you cannot specify both `overview` field and `pages` field.
+	Overview string `json:"overview,omitempty"`
+
+	// Pages: The top level pages for the documentation set.
+	Pages []*Page `json:"pages,omitempty"`
+
+	// Rules: A list of documentation rules that apply to individual API
+	// elements.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*DocumentationRule `json:"rules,omitempty"`
+
+	// Summary: A short summary of what the service does. Can only be
+	// provided by
+	// plain text.
+	Summary string `json:"summary,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "DocumentationRootUrl") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DocumentationRootUrl") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Documentation) MarshalJSON() ([]byte, error) {
+	type NoMethod Documentation
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DocumentationRule: A documentation rule provides information about
+// individual API elements.
+type DocumentationRule struct {
+	// DeprecationDescription: Deprecation description of the selected
+	// element(s). It can be provided if an
+	// element is marked as `deprecated`.
+	DeprecationDescription string `json:"deprecationDescription,omitempty"`
+
+	// Description: Description of the selected API(s).
+	Description string `json:"description,omitempty"`
+
+	// Selector: The selector is a comma-separated list of patterns. Each
+	// pattern is a
+	// qualified name of the element which may end in "*", indicating a
+	// wildcard.
+	// Wildcards are only allowed at the end and for a whole component of
+	// the
+	// qualified name, i.e. "foo.*" is ok, but not "foo.b*" or "foo.*.bar".
+	// To
+	// specify a default for all applicable elements, the whole pattern
+	// "*"
+	// is used.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "DeprecationDescription") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DeprecationDescription")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DocumentationRule) MarshalJSON() ([]byte, error) {
+	type NoMethod DocumentationRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Endpoint: `Endpoint` describes a network endpoint that serves a set
+// of APIs.
+// A service may expose any number of endpoints, and all endpoints share
+// the
+// same service configuration, such as quota configuration and
+// monitoring
+// configuration.
+//
+// Example service configuration:
+//
+//     name: library-example.googleapis.com
+//     endpoints:
+//       # Below entry makes 'google.example.library.v1.Library'
+//       # API be served from endpoint address
+// library-example.googleapis.com.
+//       # It also allows HTTP OPTIONS calls to be passed to the
+// backend, for
+//       # it to decide whether the subsequent cross-origin request is
+//       # allowed to proceed.
+//     - name: library-example.googleapis.com
+//       allow_cors: true
+type Endpoint struct {
+	// Aliases: DEPRECATED: This field is no longer supported. Instead of
+	// using aliases,
+	// please specify multiple google.api.Endpoint for each of the
+	// intended
+	// aliases.
+	//
+	// Additional names that this endpoint will be hosted on.
+	Aliases []string `json:"aliases,omitempty"`
+
+	// AllowCors:
+	// Allowing
+	// [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sh
+	// aring), aka
+	// cross-domain traffic, would allow the backends served from this
+	// endpoint to
+	// receive and respond to HTTP OPTIONS requests. The response will be
+	// used by
+	// the browser to determine whether the subsequent cross-origin request
+	// is
+	// allowed to proceed.
+	AllowCors bool `json:"allowCors,omitempty"`
+
+	// Features: The list of features enabled on this endpoint.
+	Features []string `json:"features,omitempty"`
+
+	// Name: The canonical name of this endpoint.
+	Name string `json:"name,omitempty"`
+
+	// Target: The specification of an Internet routable address of API
+	// frontend that will
+	// handle requests to this [API
+	// Endpoint](https://cloud.google.com/apis/design/glossary).
+	// It should be either a valid IPv4 address or a fully-qualified domain
+	// name.
+	// For example, "8.8.8.8" or "myservice.appspot.com".
+	Target string `json:"target,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Aliases") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Aliases") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Endpoint) MarshalJSON() ([]byte, error) {
+	type NoMethod Endpoint
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Enum: Enum type definition.
+type Enum struct {
+	// Enumvalue: Enum value definitions.
+	Enumvalue []*EnumValue `json:"enumvalue,omitempty"`
+
+	// Name: Enum type name.
+	Name string `json:"name,omitempty"`
+
+	// Options: Protocol buffer options.
+	Options []*Option `json:"options,omitempty"`
+
+	// SourceContext: The source context.
+	SourceContext *SourceContext `json:"sourceContext,omitempty"`
+
+	// Syntax: The source syntax.
+	//
+	// Possible values:
+	//   "SYNTAX_PROTO2" - Syntax `proto2`.
+	//   "SYNTAX_PROTO3" - Syntax `proto3`.
+	Syntax string `json:"syntax,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Enumvalue") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Enumvalue") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Enum) MarshalJSON() ([]byte, error) {
+	type NoMethod Enum
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// EnumValue: Enum value definition.
+type EnumValue struct {
+	// Name: Enum value name.
+	Name string `json:"name,omitempty"`
+
+	// Number: Enum value number.
+	Number int64 `json:"number,omitempty"`
+
+	// Options: Protocol buffer options.
+	Options []*Option `json:"options,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *EnumValue) MarshalJSON() ([]byte, error) {
+	type NoMethod EnumValue
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Experimental: Experimental service configuration. These configuration
+// options can
+// only be used by whitelisted users.
+type Experimental struct {
+	// Authorization: Authorization configuration.
+	Authorization *AuthorizationConfig `json:"authorization,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Authorization") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Authorization") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Experimental) MarshalJSON() ([]byte, error) {
+	type NoMethod Experimental
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Field: A single field of a message type.
+type Field struct {
+	// Cardinality: The field cardinality.
+	//
+	// Possible values:
+	//   "CARDINALITY_UNKNOWN" - For fields with unknown cardinality.
+	//   "CARDINALITY_OPTIONAL" - For optional fields.
+	//   "CARDINALITY_REQUIRED" - For required fields. Proto2 syntax only.
+	//   "CARDINALITY_REPEATED" - For repeated fields.
+	Cardinality string `json:"cardinality,omitempty"`
+
+	// DefaultValue: The string value of the default value of this field.
+	// Proto2 syntax only.
+	DefaultValue string `json:"defaultValue,omitempty"`
+
+	// JsonName: The field JSON name.
+	JsonName string `json:"jsonName,omitempty"`
+
+	// Kind: The field type.
+	//
+	// Possible values:
+	//   "TYPE_UNKNOWN" - Field type unknown.
+	//   "TYPE_DOUBLE" - Field type double.
+	//   "TYPE_FLOAT" - Field type float.
+	//   "TYPE_INT64" - Field type int64.
+	//   "TYPE_UINT64" - Field type uint64.
+	//   "TYPE_INT32" - Field type int32.
+	//   "TYPE_FIXED64" - Field type fixed64.
+	//   "TYPE_FIXED32" - Field type fixed32.
+	//   "TYPE_BOOL" - Field type bool.
+	//   "TYPE_STRING" - Field type string.
+	//   "TYPE_GROUP" - Field type group. Proto2 syntax only, and
+	// deprecated.
+	//   "TYPE_MESSAGE" - Field type message.
+	//   "TYPE_BYTES" - Field type bytes.
+	//   "TYPE_UINT32" - Field type uint32.
+	//   "TYPE_ENUM" - Field type enum.
+	//   "TYPE_SFIXED32" - Field type sfixed32.
+	//   "TYPE_SFIXED64" - Field type sfixed64.
+	//   "TYPE_SINT32" - Field type sint32.
+	//   "TYPE_SINT64" - Field type sint64.
+	Kind string `json:"kind,omitempty"`
+
+	// Name: The field name.
+	Name string `json:"name,omitempty"`
+
+	// Number: The field number.
+	Number int64 `json:"number,omitempty"`
+
+	// OneofIndex: The index of the field type in `Type.oneofs`, for message
+	// or enumeration
+	// types. The first type has index 1; zero means the type is not in the
+	// list.
+	OneofIndex int64 `json:"oneofIndex,omitempty"`
+
+	// Options: The protocol buffer options.
+	Options []*Option `json:"options,omitempty"`
+
+	// Packed: Whether to use alternative packed wire representation.
+	Packed bool `json:"packed,omitempty"`
+
+	// TypeUrl: The field type URL, without the scheme, for message or
+	// enumeration
+	// types. Example: "type.googleapis.com/google.protobuf.Timestamp".
+	TypeUrl string `json:"typeUrl,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Cardinality") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Cardinality") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Field) MarshalJSON() ([]byte, error) {
+	type NoMethod Field
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Http: Defines the HTTP configuration for an API service. It contains
+// a list of
+// HttpRule, each specifying the mapping of an RPC method
+// to one or more HTTP REST API methods.
+type Http struct {
+	// FullyDecodeReservedExpansion: When set to true, URL path parmeters
+	// will be fully URI-decoded except in
+	// cases of single segment matches in reserved expansion, where "%2F"
+	// will be
+	// left encoded.
+	//
+	// The default behavior is to not decode RFC 6570 reserved characters in
+	// multi
+	// segment matches.
+	FullyDecodeReservedExpansion bool `json:"fullyDecodeReservedExpansion,omitempty"`
+
+	// Rules: A list of HTTP configuration rules that apply to individual
+	// API methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*HttpRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "FullyDecodeReservedExpansion") to unconditionally include in API
+	// requests. By default, fields with empty values are omitted from API
+	// requests. However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g.
+	// "FullyDecodeReservedExpansion") to include in API requests with the
+	// JSON null value. By default, fields with empty values are omitted
+	// from API requests. However, any field with an empty value appearing
+	// in NullFields will be sent to the server as null. It is an error if a
+	// field in this list has a non-empty value. This may be used to include
+	// null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Http) MarshalJSON() ([]byte, error) {
+	type NoMethod Http
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// HttpRule: # gRPC Transcoding
+//
+// gRPC Transcoding is a feature for mapping between a gRPC method and
+// one or
+// more HTTP REST endpoints. It allows developers to build a single API
+// service
+// that supports both gRPC APIs and REST APIs. Many systems, including
+// [Google
+// APIs](https://github.com/googleapis/googleapis),
+// [Cloud Endpoints](https://cloud.google.com/endpoints),
+// [gRPC
+// Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
+// and [Envoy](https://github.com/envoyproxy/envoy) proxy support this
+// feature
+// and use it for large scale production services.
+//
+// `HttpRule` defines the schema of the gRPC/REST mapping. The mapping
+// specifies
+// how different portions of the gRPC request message are mapped to the
+// URL
+// path, URL query parameters, and HTTP request body. It also controls
+// how the
+// gRPC response message is mapped to the HTTP response body. `HttpRule`
+// is
+// typically specified as an `google.api.http` annotation on the gRPC
+// method.
+//
+// Each mapping specifies a URL path template and an HTTP method. The
+// path
+// template may refer to one or more fields in the gRPC request message,
+// as long
+// as each field is a non-repeated field with a primitive (non-message)
+// type.
+// The path template controls how fields of the request message are
+// mapped to
+// the URL path.
+//
+// Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get: "/v1/{name=messages/*}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string name = 1; // Mapped to URL path.
+//     }
+//     message Message {
+//       string text = 1; // The resource content.
+//     }
+//
+// This enables an HTTP REST to gRPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456`  | `GetMessage(name:
+// "messages/123456")`
+//
+// Any fields in the request message which are not bound by the path
+// template
+// automatically become HTTP query parameters if there is no HTTP
+// request body.
+// For example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get:"/v1/messages/{message_id}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       message SubMessage {
+//         string subfield = 1;
+//       }
+//       string message_id = 1; // Mapped to URL path.
+//       int64 revision = 2;    // Mapped to URL query parameter
+// `revision`.
+//       SubMessage sub = 3;    // Mapped to URL query parameter
+// `sub.subfield`.
+//     }
+//
+// This enables a HTTP JSON to RPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
+// `GetMessage(message_id: "123456" revision: 2 sub:
+// SubMessage(subfield: "foo"))`
+//
+// Note that fields which are mapped to URL query parameters must have
+// a
+// primitive type or a repeated primitive type or a non-repeated message
+// type.
+// In the case of a repeated type, the parameter can be repeated in the
+// URL
+// as `...?param=A&param=B`. In the case of a message type, each field
+// of the
+// message is mapped to a separate parameter, such
+// as
+// `...?foo.a=A&foo.b=B&foo.c=C`.
+//
+// For HTTP methods that allow a request body, the `body`
+// field
+// specifies the mapping. Consider a REST update method on the
+// message resource collection:
+//
+//     service Messaging {
+//       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "message"
+//         };
+//       }
+//     }
+//     message UpdateMessageRequest {
+//       string message_id = 1; // mapped to the URL
+//       Message message = 2;   // mapped to the body
+//     }
+//
+// The following HTTP JSON to RPC mapping is enabled, where
+// the
+// representation of the JSON in the request body is determined
+// by
+// protos JSON encoding:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` |
+// `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
+//
+// The special name `*` can be used in the body mapping to define
+// that
+// every field not bound by the path template should be mapped to
+// the
+// request body.  This enables the following alternative definition
+// of
+// the update method:
+//
+//     service Messaging {
+//       rpc UpdateMessage(Message) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "*"
+//         };
+//       }
+//     }
+//     message Message {
+//       string message_id = 1;
+//       string text = 2;
+//     }
+//
+//
+// The following HTTP JSON to RPC mapping is enabled:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` |
+// `UpdateMessage(message_id: "123456" text: "Hi!")`
+//
+// Note that when using `*` in the body mapping, it is not possible
+// to
+// have HTTP parameters, as all fields not bound by the path end in
+// the body. This makes this option more rarely used in practice
+// when
+// defining REST APIs. The common usage of `*` is in custom
+// methods
+// which don't use the URL at all for transferring data.
+//
+// It is possible to define multiple HTTP methods for one RPC by
+// using
+// the `additional_bindings` option. Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           get: "/v1/messages/{message_id}"
+//           additional_bindings {
+//             get: "/v1/users/{user_id}/messages/{message_id}"
+//           }
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string message_id = 1;
+//       string user_id = 2;
+//     }
+//
+// This enables the following two alternative HTTP JSON to RPC
+// mappings:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me"
+// message_id: "123456")`
+//
+// ## Rules for HTTP mapping
+//
+// 1. Leaf request fields (recursive expansion nested messages in the
+// request
+//    message) are classified into three categories:
+//    - Fields referred by the path template. They are passed via the
+// URL path.
+//    - Fields referred by the HttpRule.body. They are passed via the
+// HTTP
+//      request body.
+//    - All other fields are passed via the URL query parameters, and
+// the
+//      parameter name is the field path in the request message. A
+// repeated
+//      field can be represented as multiple query parameters under the
+// same
+//      name.
+//  2. If HttpRule.body is "*", there is no URL query parameter, all
+// fields
+//     are passed via URL path and HTTP request body.
+//  3. If HttpRule.body is omitted, there is no HTTP request body, all
+//     fields are passed via URL path and URL query parameters.
+//
+// ### Path template syntax
+//
+//     Template = "/" Segments [ Verb ] ;
+//     Segments = Segment { "/" Segment } ;
+//     Segment  = "*" | "**" | LITERAL | Variable ;
+//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//     FieldPath = IDENT { "." IDENT } ;
+//     Verb     = ":" LITERAL ;
+//
+// The syntax `*` matches a single URL path segment. The syntax `**`
+// matches
+// zero or more URL path segments, which must be the last part of the
+// URL path
+// except the `Verb`.
+//
+// The syntax `Variable` matches part of the URL path as specified by
+// its
+// template. A variable template must not contain other variables. If a
+// variable
+// matches a single path segment, its template may be omitted, e.g.
+// `{var}`
+// is equivalent to `{var=*}`.
+//
+// The syntax `LITERAL` matches literal text in the URL path. If the
+// `LITERAL`
+// contains any reserved character, such characters should be
+// percent-encoded
+// before the matching.
+//
+// If a variable contains exactly one path segment, such as "{var}"
+// or
+// "{var=*}", when such a variable is expanded into a URL path on the
+// client
+// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded.
+// The
+// server side does the reverse decoding. Such variables show up in
+// the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis)
+// a
+// s `{var}`.
+//
+// If a variable contains multiple path segments, such as
+// "{var=foo/*}"
+// or "{var=**}", when such a variable is expanded into a URL path on
+// the
+// client side, all characters except `[-_.~/0-9a-zA-Z]` are
+// percent-encoded.
+// The server side does the reverse decoding, except "%2F" and "%2f" are
+// left
+// unchanged. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis)
+// a
+// s `{+var}`.
+//
+// ## Using gRPC API Service Configuration
+//
+// gRPC API Service Configuration (service config) is a configuration
+// language
+// for configuring a gRPC service to become a user-facing product.
+// The
+// service config is simply the YAML representation of the
+// `google.api.Service`
+// proto message.
+//
+// As an alternative to annotating your proto file, you can configure
+// gRPC
+// transcoding in your service config YAML files. You do this by
+// specifying a
+// `HttpRule` that maps the gRPC method to a REST endpoint, achieving
+// the same
+// effect as the proto annotation. This can be particularly useful if
+// you
+// have a proto that is reused in multiple services. Note that any
+// transcoding
+// specified in the service config will override any matching
+// transcoding
+// configuration in the proto.
+//
+// Example:
+//
+//     http:
+//       rules:
+//         # Selects a gRPC method and applies HttpRule to it.
+//         - selector: example.v1.Messaging.GetMessage
+//           get: /v1/messages/{message_id}/{sub.subfield}
+//
+// ## Special notes
+//
+// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints,
+// the
+// proto to JSON conversion must follow the
+// [proto3
+// specification](https://developers.google.com/protocol-buffers/
+// docs/proto3#json).
+//
+// While the single segment variable follows the semantics of
+// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple
+// String
+// Expansion, the multi segment variable **does not** follow RFC 6570
+// Section
+// 3.2.3 Reserved Expansion. The reason is that the Reserved
+// Expansion
+// does not expand special characters like `?` and `#`, which would
+// lead
+// to invalid URLs. As the result, gRPC Transcoding uses a custom
+// encoding
+// for multi segment variables.
+//
+// The path variables **must not** refer to any repeated or mapped
+// field,
+// because client libraries are not capable of handling such variable
+// expansion.
+//
+// The path variables **must not** capture the leading "/" character.
+// The reason
+// is that the most common use case "{var}" does not capture the leading
+// "/"
+// character. For consistency, all path variables must share the same
+// behavior.
+//
+// Repeated message fields must not be mapped to URL query parameters,
+// because
+// no client library can support such complicated mapping.
+//
+// If an API needs to use a JSON array for request or response body, it
+// can map
+// the request or response body to a repeated field. However, some
+// gRPC
+// Transcoding implementations may not support this feature.
+type HttpRule struct {
+	// AdditionalBindings: Additional HTTP bindings for the selector. Nested
+	// bindings must
+	// not contain an `additional_bindings` field themselves (that is,
+	// the nesting may only be one level deep).
+	AdditionalBindings []*HttpRule `json:"additionalBindings,omitempty"`
+
+	// Body: The name of the request field whose value is mapped to the HTTP
+	// request
+	// body, or `*` for mapping all request fields not captured by the
+	// path
+	// pattern to the HTTP body, or omitted for not having any HTTP request
+	// body.
+	//
+	// NOTE: the referred field must be present at the top-level of the
+	// request
+	// message type.
+	Body string `json:"body,omitempty"`
+
+	// Custom: The custom pattern is used for specifying an HTTP method that
+	// is not
+	// included in the `pattern` field, such as HEAD, or "*" to leave
+	// the
+	// HTTP method unspecified for this rule. The wild-card rule is
+	// useful
+	// for services that provide content to Web (HTML) clients.
+	Custom *CustomHttpPattern `json:"custom,omitempty"`
+
+	// Delete: Maps to HTTP DELETE. Used for deleting a resource.
+	Delete string `json:"delete,omitempty"`
+
+	// Get: Maps to HTTP GET. Used for listing and getting information
+	// about
+	// resources.
+	Get string `json:"get,omitempty"`
+
+	// Patch: Maps to HTTP PATCH. Used for updating a resource.
+	Patch string `json:"patch,omitempty"`
+
+	// Post: Maps to HTTP POST. Used for creating a resource or performing
+	// an action.
+	Post string `json:"post,omitempty"`
+
+	// Put: Maps to HTTP PUT. Used for replacing a resource.
+	Put string `json:"put,omitempty"`
+
+	// ResponseBody: Optional. The name of the response field whose value is
+	// mapped to the HTTP
+	// response body. When omitted, the entire response message will be
+	// used
+	// as the HTTP response body.
+	//
+	// NOTE: The referred field must be present at the top-level of the
+	// response
+	// message type.
+	ResponseBody string `json:"responseBody,omitempty"`
+
+	// Selector: Selects a method to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "AdditionalBindings")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AdditionalBindings") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *HttpRule) MarshalJSON() ([]byte, error) {
+	type NoMethod HttpRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LabelDescriptor: A description of a label.
+type LabelDescriptor struct {
+	// Description: A human-readable description for the label.
+	Description string `json:"description,omitempty"`
+
+	// Key: The label key.
+	Key string `json:"key,omitempty"`
+
+	// ValueType: The type of data that can be assigned to the label.
+	//
+	// Possible values:
+	//   "STRING" - A variable-length string. This is the default.
+	//   "BOOL" - Boolean; true or false.
+	//   "INT64" - A 64-bit signed integer.
+	ValueType string `json:"valueType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LabelDescriptor) MarshalJSON() ([]byte, error) {
+	type NoMethod LabelDescriptor
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListConnectionsResponse: ListConnectionsResponse is the response to
+// list peering states for the
+// given service and consumer project.
+type ListConnectionsResponse struct {
+	// Connections: The list of Connections.
+	Connections []*Connection `json:"connections,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Connections") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Connections") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListConnectionsResponse) MarshalJSON() ([]byte, error) {
+	type NoMethod ListConnectionsResponse
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LogDescriptor: A description of a log type. Example in YAML format:
+//
+//     - name: library.googleapis.com/activity_history
+//       description: The history of borrowing and returning library
+// items.
+//       display_name: Activity
+//       labels:
+//       - key: /customer_id
+//         description: Identifier of a library customer
+type LogDescriptor struct {
+	// Description: A human-readable description of this log. This
+	// information appears in
+	// the documentation and can contain details.
+	Description string `json:"description,omitempty"`
+
+	// DisplayName: The human-readable name for this log. This information
+	// appears on
+	// the user interface and should be concise.
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Labels: The set of labels that are available to describe a specific
+	// log entry.
+	// Runtime requests that contain labels not specified here
+	// are
+	// considered invalid.
+	Labels []*LabelDescriptor `json:"labels,omitempty"`
+
+	// Name: The name of the log. It must be less than 512 characters long
+	// and can
+	// include the following characters: upper- and lower-case
+	// alphanumeric
+	// characters [A-Za-z0-9], and punctuation characters including
+	// slash, underscore, hyphen, period [/_-.].
+	Name string `json:"name,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LogDescriptor) MarshalJSON() ([]byte, error) {
+	type NoMethod LogDescriptor
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Logging: Logging configuration of the service.
+//
+// The following example shows how to configure logs to be sent to
+// the
+// producer and consumer projects. In the example, the
+// `activity_history`
+// log is sent to both the producer and consumer projects, whereas
+// the
+// `purchase_history` log is only sent to the producer project.
+//
+//     monitored_resources:
+//     - type: library.googleapis.com/branch
+//       labels:
+//       - key: /city
+//         description: The city where the library branch is located
+// in.
+//       - key: /name
+//         description: The name of the branch.
+//     logs:
+//     - name: activity_history
+//       labels:
+//       - key: /customer_id
+//     - name: purchase_history
+//     logging:
+//       producer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         logs:
+//         - activity_history
+//         - purchase_history
+//       consumer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         logs:
+//         - activity_history
+type Logging struct {
+	// ConsumerDestinations: Logging configurations for sending logs to the
+	// consumer project.
+	// There can be multiple consumer destinations, each one must have
+	// a
+	// different monitored resource type. A log can be used in at most
+	// one consumer destination.
+	ConsumerDestinations []*LoggingDestination `json:"consumerDestinations,omitempty"`
+
+	// ProducerDestinations: Logging configurations for sending logs to the
+	// producer project.
+	// There can be multiple producer destinations, each one must have
+	// a
+	// different monitored resource type. A log can be used in at most
+	// one producer destination.
+	ProducerDestinations []*LoggingDestination `json:"producerDestinations,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "ConsumerDestinations") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConsumerDestinations") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Logging) MarshalJSON() ([]byte, error) {
+	type NoMethod Logging
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LoggingDestination: Configuration of a specific logging destination
+// (the producer project
+// or the consumer project).
+type LoggingDestination struct {
+	// Logs: Names of the logs to be sent to this destination. Each name
+	// must
+	// be defined in the Service.logs section. If the log name is
+	// not a domain scoped name, it will be automatically prefixed with
+	// the service name followed by "/".
+	Logs []string `json:"logs,omitempty"`
+
+	// MonitoredResource: The monitored resource type. The type must be
+	// defined in the
+	// Service.monitored_resources section.
+	MonitoredResource string `json:"monitoredResource,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Logs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Logs") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LoggingDestination) MarshalJSON() ([]byte, error) {
+	type NoMethod LoggingDestination
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Method: Method represents a method of an API interface.
+type Method struct {
+	// Name: The simple name of this method.
+	Name string `json:"name,omitempty"`
+
+	// Options: Any metadata attached to the method.
+	Options []*Option `json:"options,omitempty"`
+
+	// RequestStreaming: If true, the request is streamed.
+	RequestStreaming bool `json:"requestStreaming,omitempty"`
+
+	// RequestTypeUrl: A URL of the input message type.
+	RequestTypeUrl string `json:"requestTypeUrl,omitempty"`
+
+	// ResponseStreaming: If true, the response is streamed.
+	ResponseStreaming bool `json:"responseStreaming,omitempty"`
+
+	// ResponseTypeUrl: The URL of the output message type.
+	ResponseTypeUrl string `json:"responseTypeUrl,omitempty"`
+
+	// Syntax: The source syntax of this method.
+	//
+	// Possible values:
+	//   "SYNTAX_PROTO2" - Syntax `proto2`.
+	//   "SYNTAX_PROTO3" - Syntax `proto3`.
+	Syntax string `json:"syntax,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Method) MarshalJSON() ([]byte, error) {
+	type NoMethod Method
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MetricDescriptor: Defines a metric type and its schema. Once a metric
+// descriptor is created,
+// deleting or altering it stops data collection and makes the metric
+// type's
+// existing data unusable.
+type MetricDescriptor struct {
+	// Description: A detailed description of the metric, which can be used
+	// in documentation.
+	Description string `json:"description,omitempty"`
+
+	// DisplayName: A concise name for the metric, which can be displayed in
+	// user interfaces.
+	// Use sentence case without an ending period, for example "Request
+	// count".
+	// This field is optional but it is recommended to be set for any
+	// metrics
+	// associated with user-visible concepts, such as Quota.
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Labels: The set of labels that can be used to describe a
+	// specific
+	// instance of this metric type. For example,
+	// the
+	// `appengine.googleapis.com/http/server/response_latencies` metric
+	// type has a label for the HTTP response code, `response_code`, so
+	// you can look at latencies for successful responses or just
+	// for responses that failed.
+	Labels []*LabelDescriptor `json:"labels,omitempty"`
+
+	// Metadata: Optional. Metadata which can be used to guide usage of the
+	// metric.
+	Metadata *MetricDescriptorMetadata `json:"metadata,omitempty"`
+
+	// MetricKind: Whether the metric records instantaneous values, changes
+	// to a value, etc.
+	// Some combinations of `metric_kind` and `value_type` might not be
+	// supported.
+	//
+	// Possible values:
+	//   "METRIC_KIND_UNSPECIFIED" - Do not use this default value.
+	//   "GAUGE" - An instantaneous measurement of a value.
+	//   "DELTA" - The change in a value during a time interval.
+	//   "CUMULATIVE" - A value accumulated over a time interval.
+	// Cumulative
+	// measurements in a time series should have the same start time
+	// and increasing end times, until an event resets the cumulative
+	// value to zero and sets a new start time for the following
+	// points.
+	MetricKind string `json:"metricKind,omitempty"`
+
+	// Name: The resource name of the metric descriptor.
+	Name string `json:"name,omitempty"`
+
+	// Type: The metric type, including its DNS name prefix. The type is
+	// not
+	// URL-encoded.  All user-defined metric types have the DNS
+	// name
+	// `custom.googleapis.com` or `external.googleapis.com`.  Metric types
+	// should
+	// use a natural hierarchical grouping. For example:
+	//
+	//     "custom.googleapis.com/invoice/paid/amount"
+	//     "external.googleapis.com/prometheus/up"
+	//     "appengine.googleapis.com/http/server/response_latencies"
+	Type string `json:"type,omitempty"`
+
+	// Unit: The unit in which the metric value is reported. It is only
+	// applicable
+	// if the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`.
+	// The
+	// supported units are a subset of [The Unified Code for Units
+	// of
+	// Measure](http://unitsofmeasure.org/ucum.html) standard:
+	//
+	// **Basic units (UNIT)**
+	//
+	// * `bit`   bit
+	// * `By`    byte
+	// * `s`     second
+	// * `min`   minute
+	// * `h`     hour
+	// * `d`     day
+	//
+	// **Prefixes (PREFIX)**
+	//
+	// * `k`     kilo    (10**3)
+	// * `M`     mega    (10**6)
+	// * `G`     giga    (10**9)
+	// * `T`     tera    (10**12)
+	// * `P`     peta    (10**15)
+	// * `E`     exa     (10**18)
+	// * `Z`     zetta   (10**21)
+	// * `Y`     yotta   (10**24)
+	// * `m`     milli   (10**-3)
+	// * `u`     micro   (10**-6)
+	// * `n`     nano    (10**-9)
+	// * `p`     pico    (10**-12)
+	// * `f`     femto   (10**-15)
+	// * `a`     atto    (10**-18)
+	// * `z`     zepto   (10**-21)
+	// * `y`     yocto   (10**-24)
+	// * `Ki`    kibi    (2**10)
+	// * `Mi`    mebi    (2**20)
+	// * `Gi`    gibi    (2**30)
+	// * `Ti`    tebi    (2**40)
+	//
+	// **Grammar**
+	//
+	// The grammar also includes these connectors:
+	//
+	// * `/`    division (as an infix operator, e.g. `1/s`).
+	// * `.`    multiplication (as an infix operator, e.g. `GBy.d`)
+	//
+	// The grammar for a unit is as follows:
+	//
+	//     Expression = Component { "." Component } { "/" Component } ;
+	//
+	//     Component = ( [ PREFIX ] UNIT | "%" ) [ Annotation ]
+	//               | Annotation
+	//               | "1"
+	//               ;
+	//
+	//     Annotation = "{" NAME "}" ;
+	//
+	// Notes:
+	//
+	// * `Annotation` is just a comment if it follows a `UNIT` and is
+	//    equivalent to `1` if it is used alone. For examples,
+	//    `{requests}/s == 1/s`, `By{transmitted}/s == By/s`.
+	// * `NAME` is a sequence of non-blank printable ASCII characters not
+	//    containing '{' or '}'.
+	// * `1` represents dimensionless value 1, such as in `1/s`.
+	// * `%` represents dimensionless value 1/100, and annotates values
+	// giving
+	//    a percentage.
+	Unit string `json:"unit,omitempty"`
+
+	// ValueType: Whether the measurement is an integer, a floating-point
+	// number, etc.
+	// Some combinations of `metric_kind` and `value_type` might not be
+	// supported.
+	//
+	// Possible values:
+	//   "VALUE_TYPE_UNSPECIFIED" - Do not use this default value.
+	//   "BOOL" - The value is a boolean.
+	// This value type can be used only if the metric kind is `GAUGE`.
+	//   "INT64" - The value is a signed 64-bit integer.
+	//   "DOUBLE" - The value is a double precision floating point number.
+	//   "STRING" - The value is a text string.
+	// This value type can be used only if the metric kind is `GAUGE`.
+	//   "DISTRIBUTION" - The value is a `Distribution`.
+	//   "MONEY" - The value is money.
+	ValueType string `json:"valueType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MetricDescriptor) MarshalJSON() ([]byte, error) {
+	type NoMethod MetricDescriptor
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MetricDescriptorMetadata: Additional annotations that can be used to
+// guide the usage of a metric.
+type MetricDescriptorMetadata struct {
+	// IngestDelay: The delay of data points caused by ingestion. Data
+	// points older than this
+	// age are guaranteed to be ingested and available to be read,
+	// excluding
+	// data loss due to errors.
+	IngestDelay string `json:"ingestDelay,omitempty"`
+
+	// LaunchStage: The launch stage of the metric definition.
+	//
+	// Possible values:
+	//   "LAUNCH_STAGE_UNSPECIFIED" - Do not use this default value.
+	//   "EARLY_ACCESS" - Early Access features are limited to a closed
+	// group of testers. To use
+	// these features, you must sign up in advance and sign a Trusted
+	// Tester
+	// agreement (which includes confidentiality provisions). These features
+	// may
+	// be unstable, changed in backward-incompatible ways, and are
+	// not
+	// guaranteed to be released.
+	//   "ALPHA" - Alpha is a limited availability test for releases before
+	// they are cleared
+	// for widespread use. By Alpha, all significant design issues are
+	// resolved
+	// and we are in the process of verifying functionality. Alpha
+	// customers
+	// need to apply for access, agree to applicable terms, and have
+	// their
+	// projects whitelisted. Alpha releases don’t have to be feature
+	// complete,
+	// no SLAs are provided, and there are no technical support obligations,
+	// but
+	// they will be far enough along that customers can actually use them
+	// in
+	// test environments or for limited-use tests -- just like they would
+	// in
+	// normal production cases.
+	//   "BETA" - Beta is the point at which we are ready to open a release
+	// for any
+	// customer to use. There are no SLA or technical support obligations in
+	// a
+	// Beta release. Products will be complete from a feature perspective,
+	// but
+	// may have some open outstanding issues. Beta releases are suitable
+	// for
+	// limited production use cases.
+	//   "GA" - GA features are open to all developers and are considered
+	// stable and
+	// fully qualified for production use.
+	//   "DEPRECATED" - Deprecated features are scheduled to be shut down
+	// and removed. For more
+	// information, see the “Deprecation Policy” section of our [Terms
+	// of
+	// Service](https://cloud.google.com/terms/)
+	// and the [Google Cloud Platform Subject to the
+	// Deprecation
+	// Policy](https://cloud.google.com/terms/deprecation) documentation.
+	LaunchStage string `json:"launchStage,omitempty"`
+
+	// SamplePeriod: The sampling period of metric data points. For metrics
+	// which are written
+	// periodically, consecutive data points are stored at this time
+	// interval,
+	// excluding data loss due to errors. Metrics with a higher granularity
+	// have
+	// a smaller sampling period.
+	SamplePeriod string `json:"samplePeriod,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "IngestDelay") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "IngestDelay") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MetricDescriptorMetadata) MarshalJSON() ([]byte, error) {
+	type NoMethod MetricDescriptorMetadata
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MetricRule: Bind API methods to metrics. Binding a method to a metric
+// causes that
+// metric's configured quota behaviors to apply to the method call.
+type MetricRule struct {
+	// MetricCosts: Metrics to update when the selected methods are called,
+	// and the associated
+	// cost applied to each metric.
+	//
+	// The key of the map is the metric name, and the values are the
+	// amount
+	// increased for the metric against which the quota limits are
+	// defined.
+	// The value must not be negative.
+	MetricCosts map[string]string `json:"metricCosts,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "MetricCosts") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "MetricCosts") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MetricRule) MarshalJSON() ([]byte, error) {
+	type NoMethod MetricRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Mixin: Declares an API Interface to be included in this interface.
+// The including
+// interface must redeclare all the methods from the included interface,
+// but
+// documentation and options are inherited as follows:
+//
+// - If after comment and whitespace stripping, the documentation
+//   string of the redeclared method is empty, it will be inherited
+//   from the original method.
+//
+// - Each annotation belonging to the service config (http,
+//   visibility) which is not set in the redeclared method will be
+//   inherited.
+//
+// - If an http annotation is inherited, the path pattern will be
+//   modified as follows. Any version prefix will be replaced by the
+//   version of the including interface plus the root path if
+//   specified.
+//
+// Example of a simple mixin:
+//
+//     package google.acl.v1;
+//     service AccessControl {
+//       // Get the underlying ACL object.
+//       rpc GetAcl(GetAclRequest) returns (Acl) {
+//         option (google.api.http).get = "/v1/{resource=**}:getAcl";
+//       }
+//     }
+//
+//     package google.storage.v2;
+//     service Storage {
+//       //       rpc GetAcl(GetAclRequest) returns (Acl);
+//
+//       // Get a data record.
+//       rpc GetData(GetDataRequest) returns (Data) {
+//         option (google.api.http).get = "/v2/{resource=**}";
+//       }
+//     }
+//
+// Example of a mixin configuration:
+//
+//     apis:
+//     - name: google.storage.v2.Storage
+//       mixins:
+//       - name: google.acl.v1.AccessControl
+//
+// The mixin construct implies that all methods in `AccessControl`
+// are
+// also declared with same name and request/response types in
+// `Storage`. A documentation generator or annotation processor will
+// see the effective `Storage.GetAcl` method after
+// inherting
+// documentation and annotations as follows:
+//
+//     service Storage {
+//       // Get the underlying ACL object.
+//       rpc GetAcl(GetAclRequest) returns (Acl) {
+//         option (google.api.http).get = "/v2/{resource=**}:getAcl";
+//       }
+//       ...
+//     }
+//
+// Note how the version in the path pattern changed from `v1` to
+// `v2`.
+//
+// If the `root` field in the mixin is specified, it should be
+// a
+// relative path under which inherited HTTP paths are placed. Example:
+//
+//     apis:
+//     - name: google.storage.v2.Storage
+//       mixins:
+//       - name: google.acl.v1.AccessControl
+//         root: acls
+//
+// This implies the following inherited HTTP annotation:
+//
+//     service Storage {
+//       // Get the underlying ACL object.
+//       rpc GetAcl(GetAclRequest) returns (Acl) {
+//         option (google.api.http).get =
+// "/v2/acls/{resource=**}:getAcl";
+//       }
+//       ...
+//     }
+type Mixin struct {
+	// Name: The fully qualified name of the interface which is included.
+	Name string `json:"name,omitempty"`
+
+	// Root: If non-empty specifies a path under which inherited HTTP
+	// paths
+	// are rooted.
+	Root string `json:"root,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Mixin) MarshalJSON() ([]byte, error) {
+	type NoMethod Mixin
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MonitoredResourceDescriptor: An object that describes the schema of a
+// MonitoredResource object using a
+// type name and a set of labels.  For example, the monitored
+// resource
+// descriptor for Google Compute Engine VM instances has a type
+// of
+// "gce_instance" and specifies the use of the labels "instance_id"
+// and
+// "zone" to identify particular VM instances.
+//
+// Different APIs can support different monitored resource types. APIs
+// generally
+// provide a `list` method that returns the monitored resource
+// descriptors used
+// by the API.
+type MonitoredResourceDescriptor struct {
+	// Description: Optional. A detailed description of the monitored
+	// resource type that might
+	// be used in documentation.
+	Description string `json:"description,omitempty"`
+
+	// DisplayName: Optional. A concise name for the monitored resource type
+	// that might be
+	// displayed in user interfaces. It should be a Title Cased Noun
+	// Phrase,
+	// without any article or other determiners. For example,
+	// "Google Cloud SQL Database".
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Labels: Required. A set of labels used to describe instances of this
+	// monitored
+	// resource type. For example, an individual Google Cloud SQL database
+	// is
+	// identified by values for the labels "database_id" and "zone".
+	Labels []*LabelDescriptor `json:"labels,omitempty"`
+
+	// Name: Optional. The resource name of the monitored resource
+	// descriptor:
+	// "projects/{project_id}/monitoredResourceDescriptors/{type
+	// }" where
+	// {type} is the value of the `type` field in this object
+	// and
+	// {project_id} is a project ID that provides API-specific context
+	// for
+	// accessing the type.  APIs that do not use project information can use
+	// the
+	// resource name format "monitoredResourceDescriptors/{type}".
+	Name string `json:"name,omitempty"`
+
+	// Type: Required. The monitored resource type. For example, the
+	// type
+	// "cloudsql_database" represents databases in Google Cloud SQL.
+	// The maximum length of this value is 256 characters.
+	Type string `json:"type,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MonitoredResourceDescriptor) MarshalJSON() ([]byte, error) {
+	type NoMethod MonitoredResourceDescriptor
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Monitoring: Monitoring configuration of the service.
+//
+// The example below shows how to configure monitored resources and
+// metrics
+// for monitoring. In the example, a monitored resource and two metrics
+// are
+// defined. The `library.googleapis.com/book/returned_count` metric is
+// sent
+// to both producer and consumer projects, whereas
+// the
+// `library.googleapis.com/book/overdue_count` metric is only sent to
+// the
+// consumer project.
+//
+//     monitored_resources:
+//     - type: library.googleapis.com/branch
+//       labels:
+//       - key: /city
+//         description: The city where the library branch is located
+// in.
+//       - key: /name
+//         description: The name of the branch.
+//     metrics:
+//     - name: library.googleapis.com/book/returned_count
+//       metric_kind: DELTA
+//       value_type: INT64
+//       labels:
+//       - key: /customer_id
+//     - name: library.googleapis.com/book/overdue_count
+//       metric_kind: GAUGE
+//       value_type: INT64
+//       labels:
+//       - key: /customer_id
+//     monitoring:
+//       producer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         metrics:
+//         - library.googleapis.com/book/returned_count
+//       consumer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         metrics:
+//         - library.googleapis.com/book/returned_count
+//         - library.googleapis.com/book/overdue_count
+type Monitoring struct {
+	// ConsumerDestinations: Monitoring configurations for sending metrics
+	// to the consumer project.
+	// There can be multiple consumer destinations, each one must have
+	// a
+	// different monitored resource type. A metric can be used in at
+	// most
+	// one consumer destination.
+	ConsumerDestinations []*MonitoringDestination `json:"consumerDestinations,omitempty"`
+
+	// ProducerDestinations: Monitoring configurations for sending metrics
+	// to the producer project.
+	// There can be multiple producer destinations, each one must have
+	// a
+	// different monitored resource type. A metric can be used in at
+	// most
+	// one producer destination.
+	ProducerDestinations []*MonitoringDestination `json:"producerDestinations,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "ConsumerDestinations") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConsumerDestinations") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Monitoring) MarshalJSON() ([]byte, error) {
+	type NoMethod Monitoring
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MonitoringDestination: Configuration of a specific monitoring
+// destination (the producer project
+// or the consumer project).
+type MonitoringDestination struct {
+	// Metrics: Names of the metrics to report to this monitoring
+	// destination.
+	// Each name must be defined in Service.metrics section.
+	Metrics []string `json:"metrics,omitempty"`
+
+	// MonitoredResource: The monitored resource type. The type must be
+	// defined in
+	// Service.monitored_resources section.
+	MonitoredResource string `json:"monitoredResource,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Metrics") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Metrics") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MonitoringDestination) MarshalJSON() ([]byte, error) {
+	type NoMethod MonitoringDestination
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// OAuthRequirements: OAuth scopes are a way to define data and
+// permissions on data. For example,
+// there are scopes defined for "Read-only access to Google Calendar"
+// and
+// "Access to Cloud Platform". Users can consent to a scope for an
+// application,
+// giving it permission to access that data on their behalf.
+//
+// OAuth scope specifications should be fairly coarse grained; a user
+// will need
+// to see and understand the text description of what your scope
+// means.
+//
+// In most cases: use one or at most two OAuth scopes for an entire
+// family of
+// products. If your product has multiple APIs, you should probably be
+// sharing
+// the OAuth scope across all of those APIs.
+//
+// When you need finer grained OAuth consent screens: talk with your
+// product
+// management about how developers will use them in practice.
+//
+// Please note that even though each of the canonical scopes is enough
+// for a
+// request to be accepted and passed to the backend, a request can still
+// fail
+// due to the backend requiring additional scopes or permissions.
+type OAuthRequirements struct {
+	// CanonicalScopes: The list of publicly documented OAuth scopes that
+	// are allowed access. An
+	// OAuth token containing any of these scopes will be
+	// accepted.
+	//
+	// Example:
+	//
+	//      canonical_scopes: https://www.googleapis.com/auth/calendar,
+	//                        https://www.googleapis.com/auth/calendar.read
+	CanonicalScopes string `json:"canonicalScopes,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "CanonicalScopes") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CanonicalScopes") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *OAuthRequirements) MarshalJSON() ([]byte, error) {
+	type NoMethod OAuthRequirements
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Operation: This resource represents a long-running operation that is
+// the result of a
+// network API call.
+type Operation struct {
+	// Done: If the value is `false`, it means the operation is still in
+	// progress.
+	// If `true`, the operation is completed, and either `error` or
+	// `response` is
+	// available.
+	Done bool `json:"done,omitempty"`
+
+	// Error: The error result of the operation in case of failure or
+	// cancellation.
+	Error *Status `json:"error,omitempty"`
+
+	// Metadata: Service-specific metadata associated with the operation.
+	// It typically
+	// contains progress information and common metadata such as create
+	// time.
+	// Some services might not provide such metadata.  Any method that
+	// returns a
+	// long-running operation should document the metadata type, if any.
+	Metadata googleapi.RawMessage `json:"metadata,omitempty"`
+
+	// Name: The server-assigned name, which is only unique within the same
+	// service that
+	// originally returns it. If you use the default HTTP mapping,
+	// the
+	// `name` should have the format of `operations/some/unique/name`.
+	Name string `json:"name,omitempty"`
+
+	// Response: The normal response of the operation in case of success.
+	// If the original
+	// method returns no data on success, such as `Delete`, the response
+	// is
+	// `google.protobuf.Empty`.  If the original method is
+	// standard
+	// `Get`/`Create`/`Update`, the response should be the resource.  For
+	// other
+	// methods, the response should have the type `XxxResponse`, where
+	// `Xxx`
+	// is the original method name.  For example, if the original method
+	// name
+	// is `TakeSnapshot()`, the inferred response type
+	// is
+	// `TakeSnapshotResponse`.
+	Response googleapi.RawMessage `json:"response,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Done") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Done") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Operation) MarshalJSON() ([]byte, error) {
+	type NoMethod Operation
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Option: A protocol buffer option, which can be attached to a message,
+// field,
+// enumeration, etc.
+type Option struct {
+	// Name: The option's name. For protobuf built-in options (options
+	// defined in
+	// descriptor.proto), this is the short name. For example,
+	// "map_entry".
+	// For custom options, it should be the fully-qualified name. For
+	// example,
+	// "google.api.http".
+	Name string `json:"name,omitempty"`
+
+	// Value: The option's value packed in an Any message. If the value is a
+	// primitive,
+	// the corresponding wrapper type defined in
+	// google/protobuf/wrappers.proto
+	// should be used. If the value is an enum, it should be stored as an
+	// int32
+	// value using the google.protobuf.Int32Value type.
+	Value googleapi.RawMessage `json:"value,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Option) MarshalJSON() ([]byte, error) {
+	type NoMethod Option
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Page: Represents a documentation page. A page can contain subpages to
+// represent
+// nested documentation set structure.
+type Page struct {
+	// Content: The Markdown content of the page. You can use <code>&#40;==
+	// include {path} ==&#41;</code>
+	// to include content from a Markdown file.
+	Content string `json:"content,omitempty"`
+
+	// Name: The name of the page. It will be used as an identity of the
+	// page to
+	// generate URI of the page, text of the link to this page in
+	// navigation,
+	// etc. The full page name (start from the root page name to this
+	// page
+	// concatenated with `.`) can be used as reference to the page in
+	// your
+	// documentation. For example:
+	// <pre><code>pages:
+	// - name: Tutorial
+	//   content: &#40;== include tutorial.md ==&#41;
+	//   subpages:
+	//   - name: Java
+	//     content: &#40;== include tutorial_java.md
+	// ==&#41;
+	// </code></pre>
+	// You can reference `Java` page using Markdown reference link
+	// syntax:
+	// `Java`.
+	Name string `json:"name,omitempty"`
+
+	// Subpages: Subpages of this page. The order of subpages specified here
+	// will be
+	// honored in the generated docset.
+	Subpages []*Page `json:"subpages,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Content") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Content") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Page) MarshalJSON() ([]byte, error) {
+	type NoMethod Page
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Quota: Quota configuration helps to achieve fairness and budgeting in
+// service
+// usage.
+//
+// The quota configuration works this way:
+// - The service configuration defines a set of metrics.
+// - For API calls, the quota.metric_rules maps methods to metrics with
+//   corresponding costs.
+// - The quota.limits defines limits on the metrics, which will be used
+// for
+//   quota checks at runtime.
+//
+// An example quota configuration in yaml format:
+//
+//    quota:
+//      limits:
+//
+//      - name: apiWriteQpsPerProject
+//        metric: library.googleapis.com/write_calls
+//        unit: "1/min/{project}"  # rate limit for consumer projects
+//        values:
+//          STANDARD: 10000
+//
+//
+//      # The metric rules bind all methods to the read_calls metric,
+//      # except for the UpdateBook and DeleteBook methods. These two
+// methods
+//      # are mapped to the write_calls metric, with the UpdateBook
+// method
+//      # consuming at twice rate as the DeleteBook method.
+//      metric_rules:
+//      - selector: "*"
+//        metric_costs:
+//          library.googleapis.com/read_calls: 1
+//      - selector: google.example.library.v1.LibraryService.UpdateBook
+//        metric_costs:
+//          library.googleapis.com/write_calls: 2
+//      - selector: google.example.library.v1.LibraryService.DeleteBook
+//        metric_costs:
+//          library.googleapis.com/write_calls: 1
+//
+//  Corresponding Metric definition:
+//
+//      metrics:
+//      - name: library.googleapis.com/read_calls
+//        display_name: Read requests
+//        metric_kind: DELTA
+//        value_type: INT64
+//
+//      - name: library.googleapis.com/write_calls
+//        display_name: Write requests
+//        metric_kind: DELTA
+//        value_type: INT64
+type Quota struct {
+	// Limits: List of `QuotaLimit` definitions for the service.
+	Limits []*QuotaLimit `json:"limits,omitempty"`
+
+	// MetricRules: List of `MetricRule` definitions, each one mapping a
+	// selected method to one
+	// or more metrics.
+	MetricRules []*MetricRule `json:"metricRules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Limits") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Limits") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Quota) MarshalJSON() ([]byte, error) {
+	type NoMethod Quota
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// QuotaLimit: `QuotaLimit` defines a specific limit that applies over a
+// specified duration
+// for a limit type. There can be at most one limit for a duration and
+// limit
+// type combination defined within a `QuotaGroup`.
+type QuotaLimit struct {
+	// DefaultLimit: Default number of tokens that can be consumed during
+	// the specified
+	// duration. This is the number of tokens assigned when a
+	// client
+	// application developer activates the service for his/her
+	// project.
+	//
+	// Specifying a value of 0 will block all requests. This can be used if
+	// you
+	// are provisioning quota to selected consumers and blocking
+	// others.
+	// Similarly, a value of -1 will indicate an unlimited quota. No
+	// other
+	// negative values are allowed.
+	//
+	// Used by group-based quotas only.
+	DefaultLimit int64 `json:"defaultLimit,omitempty,string"`
+
+	// Description: Optional. User-visible, extended description for this
+	// quota limit.
+	// Should be used only when more context is needed to understand this
+	// limit
+	// than provided by the limit's display name (see: `display_name`).
+	Description string `json:"description,omitempty"`
+
+	// DisplayName: User-visible display name for this limit.
+	// Optional. If not set, the UI will provide a default display name
+	// based on
+	// the quota configuration. This field can be used to override the
+	// default
+	// display name generated from the configuration.
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Duration: Duration of this limit in textual notation. Example:
+	// "100s", "24h", "1d".
+	// For duration longer than a day, only multiple of days is supported.
+	// We
+	// support only "100s" and "1d" for now. Additional support will be
+	// added in
+	// the future. "0" indicates indefinite duration.
+	//
+	// Used by group-based quotas only.
+	Duration string `json:"duration,omitempty"`
+
+	// FreeTier: Free tier value displayed in the Developers Console for
+	// this limit.
+	// The free tier is the number of tokens that will be subtracted from
+	// the
+	// billed amount when billing is enabled.
+	// This field can only be set on a limit with duration "1d", in a
+	// billable
+	// group; it is invalid on any other limit. If this field is not set,
+	// it
+	// defaults to 0, indicating that there is no free tier for this
+	// service.
+	//
+	// Used by group-based quotas only.
+	FreeTier int64 `json:"freeTier,omitempty,string"`
+
+	// MaxLimit: Maximum number of tokens that can be consumed during the
+	// specified
+	// duration. Client application developers can override the default
+	// limit up
+	// to this maximum. If specified, this value cannot be set to a value
+	// less
+	// than the default limit. If not specified, it is set to the default
+	// limit.
+	//
+	// To allow clients to apply overrides with no upper bound, set this to
+	// -1,
+	// indicating unlimited maximum quota.
+	//
+	// Used by group-based quotas only.
+	MaxLimit int64 `json:"maxLimit,omitempty,string"`
+
+	// Metric: The name of the metric this quota limit applies to. The quota
+	// limits with
+	// the same metric will be checked together during runtime. The metric
+	// must be
+	// defined within the service config.
+	Metric string `json:"metric,omitempty"`
+
+	// Name: Name of the quota limit.
+	//
+	// The name must be provided, and it must be unique within the service.
+	// The
+	// name can only include alphanumeric characters as well as '-'.
+	//
+	// The maximum length of the limit name is 64 characters.
+	Name string `json:"name,omitempty"`
+
+	// Unit: Specify the unit of the quota limit. It uses the same syntax
+	// as
+	// Metric.unit. The supported unit kinds are determined by the
+	// quota
+	// backend system.
+	//
+	// Here are some examples:
+	// * "1/min/{project}" for quota per minute per project.
+	//
+	// Note: the order of unit components is insignificant.
+	// The "1" at the beginning is required to follow the metric unit
+	// syntax.
+	Unit string `json:"unit,omitempty"`
+
+	// Values: Tiered limit values. You must specify this as a key:value
+	// pair, with an
+	// integer value that is the maximum number of requests allowed for
+	// the
+	// specified unit. Currently only STANDARD is supported.
+	Values map[string]string `json:"values,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DefaultLimit") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DefaultLimit") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *QuotaLimit) MarshalJSON() ([]byte, error) {
+	type NoMethod QuotaLimit
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Service: `Service` is the root object of Google service configuration
+// schema. It
+// describes basic information about a service, such as the name and
+// the
+// title, and delegates other aspects to sub-sections. Each sub-section
+// is
+// either a proto message or a repeated proto message that configures
+// a
+// specific aspect, such as auth. See each proto message definition for
+// details.
+//
+// Example:
+//
+//     type: google.api.Service
+//     config_version: 3
+//     name: calendar.googleapis.com
+//     title: Google Calendar API
+//     apis:
+//     - name: google.calendar.v3.Calendar
+//     authentication:
+//       providers:
+//       - id: google_calendar_auth
+//         jwks_uri: https://www.googleapis.com/oauth2/v1/certs
+//         issuer: https://securetoken.google.com
+//       rules:
+//       - selector: "*"
+//         requirements:
+//           provider_id: google_calendar_auth
+type Service struct {
+	// Apis: A list of API interfaces exported by this service. Only the
+	// `name` field
+	// of the google.protobuf.Api needs to be provided by the
+	// configuration
+	// author, as the remaining fields will be derived from the IDL during
+	// the
+	// normalization process. It is an error to specify an API interface
+	// here
+	// which cannot be resolved against the associated IDL files.
+	Apis []*Api `json:"apis,omitempty"`
+
+	// Authentication: Auth configuration.
+	Authentication *Authentication `json:"authentication,omitempty"`
+
+	// Backend: API backend configuration.
+	Backend *Backend `json:"backend,omitempty"`
+
+	// Billing: Billing configuration.
+	Billing *Billing `json:"billing,omitempty"`
+
+	// ConfigVersion: The semantic version of the service configuration. The
+	// config version
+	// affects the interpretation of the service configuration. For
+	// example,
+	// certain features are enabled by default for certain config
+	// versions.
+	// The latest config version is `3`.
+	ConfigVersion int64 `json:"configVersion,omitempty"`
+
+	// Context: Context configuration.
+	Context *Context `json:"context,omitempty"`
+
+	// Control: Configuration for the service control plane.
+	Control *Control `json:"control,omitempty"`
+
+	// CustomError: Custom error configuration.
+	CustomError *CustomError `json:"customError,omitempty"`
+
+	// Documentation: Additional API documentation.
+	Documentation *Documentation `json:"documentation,omitempty"`
+
+	// Endpoints: Configuration for network endpoints.  If this is empty,
+	// then an endpoint
+	// with the same name as the service is automatically generated to
+	// service all
+	// defined APIs.
+	Endpoints []*Endpoint `json:"endpoints,omitempty"`
+
+	// Enums: A list of all enum types included in this API service.
+	// Enums
+	// referenced directly or indirectly by the `apis` are
+	// automatically
+	// included.  Enums which are not referenced but shall be
+	// included
+	// should be listed here by name. Example:
+	//
+	//     enums:
+	//     - name: google.someapi.v1.SomeEnum
+	Enums []*Enum `json:"enums,omitempty"`
+
+	// Experimental: Experimental configuration.
+	Experimental *Experimental `json:"experimental,omitempty"`
+
+	// Http: HTTP configuration.
+	Http *Http `json:"http,omitempty"`
+
+	// Id: A unique ID for a specific instance of this message, typically
+	// assigned
+	// by the client for tracking purpose. If empty, the server may choose
+	// to
+	// generate one instead. Must be no longer than 60 characters.
+	Id string `json:"id,omitempty"`
+
+	// Logging: Logging configuration.
+	Logging *Logging `json:"logging,omitempty"`
+
+	// Logs: Defines the logs used by this service.
+	Logs []*LogDescriptor `json:"logs,omitempty"`
+
+	// Metrics: Defines the metrics used by this service.
+	Metrics []*MetricDescriptor `json:"metrics,omitempty"`
+
+	// MonitoredResources: Defines the monitored resources used by this
+	// service. This is required
+	// by the Service.monitoring and Service.logging configurations.
+	MonitoredResources []*MonitoredResourceDescriptor `json:"monitoredResources,omitempty"`
+
+	// Monitoring: Monitoring configuration.
+	Monitoring *Monitoring `json:"monitoring,omitempty"`
+
+	// Name: The DNS address at which this service is available,
+	// e.g. `calendar.googleapis.com`.
+	Name string `json:"name,omitempty"`
+
+	// ProducerProjectId: The Google project that owns this service.
+	ProducerProjectId string `json:"producerProjectId,omitempty"`
+
+	// Quota: Quota configuration.
+	Quota *Quota `json:"quota,omitempty"`
+
+	// SourceInfo: Output only. The source information for this
+	// configuration if available.
+	SourceInfo *SourceInfo `json:"sourceInfo,omitempty"`
+
+	// SystemParameters: System parameter configuration.
+	SystemParameters *SystemParameters `json:"systemParameters,omitempty"`
+
+	// SystemTypes: A list of all proto message types included in this API
+	// service.
+	// It serves similar purpose as [google.api.Service.types], except
+	// that
+	// these types are not needed by user-defined APIs. Therefore, they will
+	// not
+	// show up in the generated discovery doc. This field should only be
+	// used
+	// to define system APIs in ESF.
+	SystemTypes []*Type `json:"systemTypes,omitempty"`
+
+	// Title: The product title for this service.
+	Title string `json:"title,omitempty"`
+
+	// Types: A list of all proto message types included in this API
+	// service.
+	// Types referenced directly or indirectly by the `apis`
+	// are
+	// automatically included.  Messages which are not referenced but
+	// shall be included, such as types used by the `google.protobuf.Any`
+	// type,
+	// should be listed here by name. Example:
+	//
+	//     types:
+	//     - name: google.protobuf.Int32
+	Types []*Type `json:"types,omitempty"`
+
+	// Usage: Configuration controlling usage of this service.
+	Usage *Usage `json:"usage,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Apis") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Apis") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Service) MarshalJSON() ([]byte, error) {
+	type NoMethod Service
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceContext: `SourceContext` represents information about the
+// source of a
+// protobuf element, like the file in which it is defined.
+type SourceContext struct {
+	// FileName: The path-qualified name of the .proto file that contained
+	// the associated
+	// protobuf element.  For example:
+	// "google/protobuf/source_context.proto".
+	FileName string `json:"fileName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "FileName") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "FileName") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceContext) MarshalJSON() ([]byte, error) {
+	type NoMethod SourceContext
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceInfo: Source information used to create a Service Config
+type SourceInfo struct {
+	// SourceFiles: All files used during config generation.
+	SourceFiles []googleapi.RawMessage `json:"sourceFiles,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "SourceFiles") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "SourceFiles") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceInfo) MarshalJSON() ([]byte, error) {
+	type NoMethod SourceInfo
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Status: The `Status` type defines a logical error model that is
+// suitable for different
+// programming environments, including REST APIs and RPC APIs. It is
+// used by
+// [gRPC](https://github.com/grpc). The error model is designed to
+// be:
+//
+// - Simple to use and understand for most users
+// - Flexible enough to meet unexpected needs
+//
+// # Overview
+//
+// The `Status` message contains three pieces of data: error code, error
+// message,
+// and error details. The error code should be an enum value
+// of
+// google.rpc.Code, but it may accept additional error codes if needed.
+// The
+// error message should be a developer-facing English message that
+// helps
+// developers *understand* and *resolve* the error. If a localized
+// user-facing
+// error message is needed, put the localized message in the error
+// details or
+// localize it in the client. The optional error details may contain
+// arbitrary
+// information about the error. There is a predefined set of error
+// detail types
+// in the package `google.rpc` that can be used for common error
+// conditions.
+//
+// # Language mapping
+//
+// The `Status` message is the logical representation of the error
+// model, but it
+// is not necessarily the actual wire format. When the `Status` message
+// is
+// exposed in different client libraries and different wire protocols,
+// it can be
+// mapped differently. For example, it will likely be mapped to some
+// exceptions
+// in Java, but more likely mapped to some error codes in C.
+//
+// # Other uses
+//
+// The error model and the `Status` message can be used in a variety
+// of
+// environments, either with or without APIs, to provide a
+// consistent developer experience across different
+// environments.
+//
+// Example uses of this error model include:
+//
+// - Partial errors. If a service needs to return partial errors to the
+// client,
+//     it may embed the `Status` in the normal response to indicate the
+// partial
+//     errors.
+//
+// - Workflow errors. A typical workflow has multiple steps. Each step
+// may
+//     have a `Status` message for error reporting.
+//
+// - Batch operations. If a client uses batch request and batch
+// response, the
+//     `Status` message should be used directly inside batch response,
+// one for
+//     each error sub-response.
+//
+// - Asynchronous operations. If an API call embeds asynchronous
+// operation
+//     results in its response, the status of those operations should
+// be
+//     represented directly using the `Status` message.
+//
+// - Logging. If some API errors are stored in logs, the message
+// `Status` could
+//     be used directly after any stripping needed for security/privacy
+// reasons.
+type Status struct {
+	// Code: The status code, which should be an enum value of
+	// google.rpc.Code.
+	Code int64 `json:"code,omitempty"`
+
+	// Details: A list of messages that carry the error details.  There is a
+	// common set of
+	// message types for APIs to use.
+	Details []googleapi.RawMessage `json:"details,omitempty"`
+
+	// Message: A developer-facing error message, which should be in
+	// English. Any
+	// user-facing error message should be localized and sent in
+	// the
+	// google.rpc.Status.details field, or localized by the client.
+	Message string `json:"message,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Code") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Code") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Status) MarshalJSON() ([]byte, error) {
+	type NoMethod Status
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Subnetwork: Message returning the created service subnetwork.
+type Subnetwork struct {
+	// IpCidrRange: Subnetwork CIDR range in "10.x.x.x/y" format.
+	IpCidrRange string `json:"ipCidrRange,omitempty"`
+
+	// Name: Subnetwork name.
+	// See https://cloud.google.com/compute/docs/vpc/
+	Name string `json:"name,omitempty"`
+
+	// Network: Shared VPC host project network peered with consumer
+	// network.
+	// For example: projects/1234321/global/networks/host-network
+	Network string `json:"network,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "IpCidrRange") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "IpCidrRange") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Subnetwork) MarshalJSON() ([]byte, error) {
+	type NoMethod Subnetwork
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SystemParameter: Define a parameter's name and location. The
+// parameter may be passed as either
+// an HTTP header or a URL query parameter, and if both are passed the
+// behavior
+// is implementation-dependent.
+type SystemParameter struct {
+	// HttpHeader: Define the HTTP header name to use for the parameter. It
+	// is case
+	// insensitive.
+	HttpHeader string `json:"httpHeader,omitempty"`
+
+	// Name: Define the name of the parameter, such as "api_key" . It is
+	// case sensitive.
+	Name string `json:"name,omitempty"`
+
+	// UrlQueryParameter: Define the URL query parameter name to use for the
+	// parameter. It is case
+	// sensitive.
+	UrlQueryParameter string `json:"urlQueryParameter,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "HttpHeader") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "HttpHeader") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SystemParameter) MarshalJSON() ([]byte, error) {
+	type NoMethod SystemParameter
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SystemParameterRule: Define a system parameter rule mapping system
+// parameter definitions to
+// methods.
+type SystemParameterRule struct {
+	// Parameters: Define parameters. Multiple names may be defined for a
+	// parameter.
+	// For a given method call, only one of them should be used. If
+	// multiple
+	// names are used the behavior is implementation-dependent.
+	// If none of the specified names are present the behavior
+	// is
+	// parameter-dependent.
+	Parameters []*SystemParameter `json:"parameters,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies. Use '*' to
+	// indicate all
+	// methods in all APIs.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Parameters") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Parameters") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SystemParameterRule) MarshalJSON() ([]byte, error) {
+	type NoMethod SystemParameterRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SystemParameters: ### System parameter configuration
+//
+// A system parameter is a special kind of parameter defined by the
+// API
+// system, not by an individual API. It is typically mapped to an HTTP
+// header
+// and/or a URL query parameter. This configuration specifies which
+// methods
+// change the names of the system parameters.
+type SystemParameters struct {
+	// Rules: Define system parameters.
+	//
+	// The parameters defined here will override the default
+	// parameters
+	// implemented by the system. If this field is missing from the
+	// service
+	// config, default system parameters will be used. Default system
+	// parameters
+	// and names is implementation-dependent.
+	//
+	// Example: define api key for all methods
+	//
+	//     system_parameters
+	//       rules:
+	//         - selector: "*"
+	//           parameters:
+	//             - name: api_key
+	//               url_query_parameter: api_key
+	//
+	//
+	// Example: define 2 api key names for a specific method.
+	//
+	//     system_parameters
+	//       rules:
+	//         - selector: "/ListShelves"
+	//           parameters:
+	//             - name: api_key
+	//               http_header: Api-Key1
+	//             - name: api_key
+	//               http_header: Api-Key2
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*SystemParameterRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SystemParameters) MarshalJSON() ([]byte, error) {
+	type NoMethod SystemParameters
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Type: A protocol buffer message type.
+type Type struct {
+	// Fields: The list of fields.
+	Fields []*Field `json:"fields,omitempty"`
+
+	// Name: The fully qualified message name.
+	Name string `json:"name,omitempty"`
+
+	// Oneofs: The list of types appearing in `oneof` definitions in this
+	// type.
+	Oneofs []string `json:"oneofs,omitempty"`
+
+	// Options: The protocol buffer options.
+	Options []*Option `json:"options,omitempty"`
+
+	// SourceContext: The source context.
+	SourceContext *SourceContext `json:"sourceContext,omitempty"`
+
+	// Syntax: The source syntax.
+	//
+	// Possible values:
+	//   "SYNTAX_PROTO2" - Syntax `proto2`.
+	//   "SYNTAX_PROTO3" - Syntax `proto3`.
+	Syntax string `json:"syntax,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Fields") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Fields") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Type) MarshalJSON() ([]byte, error) {
+	type NoMethod Type
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Usage: Configuration controlling usage of a service.
+type Usage struct {
+	// ProducerNotificationChannel: The full resource name of a channel used
+	// for sending notifications to the
+	// service producer.
+	//
+	// Google Service Management currently only supports
+	// [Google Cloud Pub/Sub](https://cloud.google.com/pubsub) as a
+	// notification
+	// channel. To use Google Cloud Pub/Sub as the channel, this must be the
+	// name
+	// of a Cloud Pub/Sub topic that uses the Cloud Pub/Sub topic name
+	// format
+	// documented in https://cloud.google.com/pubsub/docs/overview.
+	ProducerNotificationChannel string `json:"producerNotificationChannel,omitempty"`
+
+	// Requirements: Requirements that must be satisfied before a consumer
+	// project can use the
+	// service. Each requirement is of the form
+	// <service.name>/<requirement-id>;
+	// for example 'serviceusage.googleapis.com/billing-enabled'.
+	Requirements []string `json:"requirements,omitempty"`
+
+	// Rules: A list of usage rules that apply to individual API
+	// methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*UsageRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "ProducerNotificationChannel") to unconditionally include in API
+	// requests. By default, fields with empty values are omitted from API
+	// requests. However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g.
+	// "ProducerNotificationChannel") to include in API requests with the
+	// JSON null value. By default, fields with empty values are omitted
+	// from API requests. However, any field with an empty value appearing
+	// in NullFields will be sent to the server as null. It is an error if a
+	// field in this list has a non-empty value. This may be used to include
+	// null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Usage) MarshalJSON() ([]byte, error) {
+	type NoMethod Usage
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// UsageRule: Usage configuration rules for the service.
+//
+// NOTE: Under development.
+//
+//
+// Use this rule to configure unregistered calls for the service.
+// Unregistered
+// calls are calls that do not contain consumer project
+// identity.
+// (Example: calls that do not contain an API key).
+// By default, API methods do not allow unregistered calls, and each
+// method call
+// must be identified by a consumer project identity. Use this rule
+// to
+// allow/disallow unregistered calls.
+//
+// Example of an API that wants to allow unregistered calls for entire
+// service.
+//
+//     usage:
+//       rules:
+//       - selector: "*"
+//         allow_unregistered_calls: true
+//
+// Example of a method that wants to allow unregistered calls.
+//
+//     usage:
+//       rules:
+//       - selector:
+// "google.example.library.v1.LibraryService.CreateBook"
+//         allow_unregistered_calls: true
+type UsageRule struct {
+	// AllowUnregisteredCalls: If true, the selected method allows
+	// unregistered calls, e.g. calls
+	// that don't identify any user or application.
+	AllowUnregisteredCalls bool `json:"allowUnregisteredCalls,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies. Use '*' to
+	// indicate all
+	// methods in all APIs.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// SkipServiceControl: If true, the selected method should skip service
+	// control and the control
+	// plane features, such as quota and billing, will not be
+	// available.
+	// This flag is used by Google Cloud Endpoints to bypass checks for
+	// internal
+	// methods, such as service health check methods.
+	SkipServiceControl bool `json:"skipServiceControl,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "AllowUnregisteredCalls") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AllowUnregisteredCalls")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *UsageRule) MarshalJSON() ([]byte, error) {
+	type NoMethod UsageRule
+	raw := NoMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// method id "servicenetworking.operations.get":
+
+type OperationsGetCall struct {
+	s            *APIService
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets the latest state of a long-running operation.  Clients can
+// use this
+// method to poll the operation result at intervals as recommended by
+// the API
+// service.
+func (r *OperationsService) Get(name string) *OperationsGetCall {
+	c := &OperationsGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *OperationsGetCall) Fields(s ...googleapi.Field) *OperationsGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *OperationsGetCall) IfNoneMatch(entityTag string) *OperationsGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *OperationsGetCall) Context(ctx context.Context) *OperationsGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *OperationsGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *OperationsGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	c.urlParams_.Set("prettyPrint", "false")
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, err := http.NewRequest("GET", urls, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicenetworking.operations.get" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *OperationsGetCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets the latest state of a long-running operation.  Clients can use this\nmethod to poll the operation result at intervals as recommended by the API\nservice.",
+	//   "flatPath": "v1beta/operations/{operationsId}",
+	//   "httpMethod": "GET",
+	//   "id": "servicenetworking.operations.get",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The name of the operation resource.",
+	//       "location": "path",
+	//       "pattern": "^operations/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1beta/{+name}",
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicenetworking.services.addSubnetwork":
+
+type ServicesAddSubnetworkCall struct {
+	s                    *APIService
+	parent               string
+	addsubnetworkrequest *AddSubnetworkRequest
+	urlParams_           gensupport.URLParams
+	ctx_                 context.Context
+	header_              http.Header
+}
+
+// AddSubnetwork: Service producers use this method to provision a new
+// subnet in
+// peered service shared VPC network.
+// It will validate previously provided allocated ranges,
+// find
+// non-conflicting sub-range of requested size (expressed in
+// number of leading bits of ipv4 network mask, as in CIDR
+// range
+// notation). It will then create a subnetwork in the request
+// region. The subsequent call will try to reuse the
+// subnetwork previously created if subnetwork name, region and
+// prefix length of the IP range match.
+// Operation<response: Subnetwork>
+func (r *ServicesService) AddSubnetwork(parent string, addsubnetworkrequest *AddSubnetworkRequest) *ServicesAddSubnetworkCall {
+	c := &ServicesAddSubnetworkCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.parent = parent
+	c.addsubnetworkrequest = addsubnetworkrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesAddSubnetworkCall) Fields(s ...googleapi.Field) *ServicesAddSubnetworkCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesAddSubnetworkCall) Context(ctx context.Context) *ServicesAddSubnetworkCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesAddSubnetworkCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesAddSubnetworkCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.addsubnetworkrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	c.urlParams_.Set("prettyPrint", "false")
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta/{+parent}:addSubnetwork")
+	urls += "?" + c.urlParams_.Encode()
+	req, err := http.NewRequest("POST", urls, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"parent": c.parent,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicenetworking.services.addSubnetwork" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesAddSubnetworkCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Service producers use this method to provision a new subnet in\npeered service shared VPC network.\nIt will validate previously provided allocated ranges, find\nnon-conflicting sub-range of requested size (expressed in\nnumber of leading bits of ipv4 network mask, as in CIDR range\nnotation). It will then create a subnetwork in the request\nregion. The subsequent call will try to reuse the\nsubnetwork previously created if subnetwork name, region and\nprefix length of the IP range match.\nOperation\u003cresponse: Subnetwork\u003e",
+	//   "flatPath": "v1beta/services/{servicesId}/{servicesId1}/{servicesId2}:addSubnetwork",
+	//   "httpMethod": "POST",
+	//   "id": "servicenetworking.services.addSubnetwork",
+	//   "parameterOrder": [
+	//     "parent"
+	//   ],
+	//   "parameters": {
+	//     "parent": {
+	//       "description": "Required. This is a 'tenant' project in the service producer organization.\nservices/{service}/{collection-id}/{resource-id}\n{collection id} is the cloud resource collection type representing the\ntenant project. Only 'projects' are currently supported.\n{resource id} is the tenant project numeric id: '123456'.\n{service} the name of the peering service, for example\n'service-peering.example.com'. This service must be activated.\nin the consumer project.",
+	//       "location": "path",
+	//       "pattern": "^services/[^/]+/[^/]+/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1beta/{+parent}:addSubnetwork",
+	//   "request": {
+	//     "$ref": "AddSubnetworkRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicenetworking.services.connections.create":
+
+type ServicesConnectionsCreateCall struct {
+	s          *APIService
+	parent     string
+	connection *Connection
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Create: To connect service to a VPC network peering connection
+// must be established prior to service provisioning.
+// This method must be invoked by the consumer VPC network
+// administrator
+// It will establish a permanent peering connection with a
+// shared
+// network created in the service producer organization and register
+// a
+// allocated IP range(s) to be used for service subnetwork
+// provisioning.
+// This connection will be used for all supported services in the
+// service
+// producer organization, so it only needs to be invoked
+// once.
+// Operation<response: Connection>.
+func (r *ServicesConnectionsService) Create(parent string, connection *Connection) *ServicesConnectionsCreateCall {
+	c := &ServicesConnectionsCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.parent = parent
+	c.connection = connection
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesConnectionsCreateCall) Fields(s ...googleapi.Field) *ServicesConnectionsCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesConnectionsCreateCall) Context(ctx context.Context) *ServicesConnectionsCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesConnectionsCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesConnectionsCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.connection)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	c.urlParams_.Set("prettyPrint", "false")
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta/{+parent}/connections")
+	urls += "?" + c.urlParams_.Encode()
+	req, err := http.NewRequest("POST", urls, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"parent": c.parent,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicenetworking.services.connections.create" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesConnectionsCreateCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "To connect service to a VPC network peering connection\nmust be established prior to service provisioning.\nThis method must be invoked by the consumer VPC network administrator\nIt will establish a permanent peering connection with a shared\nnetwork created in the service producer organization and register a\nallocated IP range(s) to be used for service subnetwork provisioning.\nThis connection will be used for all supported services in the service\nproducer organization, so it only needs to be invoked once.\nOperation\u003cresponse: Connection\u003e.",
+	//   "flatPath": "v1beta/services/{servicesId}/connections",
+	//   "httpMethod": "POST",
+	//   "id": "servicenetworking.services.connections.create",
+	//   "parameterOrder": [
+	//     "parent"
+	//   ],
+	//   "parameters": {
+	//     "parent": {
+	//       "description": "Provider peering service that is managing peering connectivity for a\nservice provider organization.\nFor Google services that support this functionality it is\n'services/servicenetworking.googleapis.com'.",
+	//       "location": "path",
+	//       "pattern": "^services/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1beta/{+parent}/connections",
+	//   "request": {
+	//     "$ref": "Connection"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicenetworking.services.connections.list":
+
+type ServicesConnectionsListCall struct {
+	s            *APIService
+	parent       string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Service consumers use this method to list configured peering
+// connection for
+// the given service and consumer network.
+func (r *ServicesConnectionsService) List(parent string) *ServicesConnectionsListCall {
+	c := &ServicesConnectionsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.parent = parent
+	return c
+}
+
+// Network sets the optional parameter "network": Network name in the
+// consumer project.   This network must have been
+// already peered with a shared VPC network using
+// CreateConnection
+// method.
+// Must be in a form
+// 'projects/{project}/global/networks/{network}'.
+// {project} is a project number, as in '12345'
+// {network} is network name.
+func (c *ServicesConnectionsListCall) Network(network string) *ServicesConnectionsListCall {
+	c.urlParams_.Set("network", network)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesConnectionsListCall) Fields(s ...googleapi.Field) *ServicesConnectionsListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ServicesConnectionsListCall) IfNoneMatch(entityTag string) *ServicesConnectionsListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesConnectionsListCall) Context(ctx context.Context) *ServicesConnectionsListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesConnectionsListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesConnectionsListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	c.urlParams_.Set("prettyPrint", "false")
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1beta/{+parent}/connections")
+	urls += "?" + c.urlParams_.Encode()
+	req, err := http.NewRequest("GET", urls, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"parent": c.parent,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicenetworking.services.connections.list" call.
+// Exactly one of *ListConnectionsResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ListConnectionsResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ServicesConnectionsListCall) Do(opts ...googleapi.CallOption) (*ListConnectionsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListConnectionsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := gensupport.DecodeResponse(target, res); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Service consumers use this method to list configured peering connection for\nthe given service and consumer network.",
+	//   "flatPath": "v1beta/services/{servicesId}/connections",
+	//   "httpMethod": "GET",
+	//   "id": "servicenetworking.services.connections.list",
+	//   "parameterOrder": [
+	//     "parent"
+	//   ],
+	//   "parameters": {
+	//     "network": {
+	//       "description": "Network name in the consumer project.   This network must have been\nalready peered with a shared VPC network using CreateConnection\nmethod.\nMust be in a form 'projects/{project}/global/networks/{network}'.\n{project} is a project number, as in '12345'\n{network} is network name.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "parent": {
+	//       "description": "Provider peering service that is managing peering connectivity for a\nservice provider organization.\nFor Google services that support this functionality it is\n'services/servicenetworking.googleapis.com'.",
+	//       "location": "path",
+	//       "pattern": "^services/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1beta/{+parent}/connections",
+	//   "response": {
+	//     "$ref": "ListConnectionsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1567,6 +1567,12 @@
 			"revisionTime": "2018-08-29T00:05:35Z"
 		},
 		{
+			"checksumSHA1": "bUJtq247QmviGtS5OF02ZLUsKQ0=",
+			"path": "google.golang.org/api/servicenetworking/v1beta",
+			"revision": "04bb50b6b83d0e72253821af8cf3252d8e866517",
+			"revisionTime": "2018-11-02T01:57:16Z"
+		},
+		{
 			"checksumSHA1": "btYwZ2kB6S9fgQLa1e9tsu1Tb7M=",
 			"path": "google.golang.org/api/serviceusage/v1beta1",
 			"revision": "087779f1d2c96357d4c45bd04c4d10d7b5f22736",
@@ -1923,5 +1929,5 @@
 			"versionExact": "v1.6.1"
 		}
 	],
-	"rootPath": "github.com/terraform-providers/terraform-provider-google"
+	"rootPath": "github.com/terraform-providers/terraform-provider-google-beta"
 }

--- a/website/docs/r/service_networking_connection.html.markdown
+++ b/website/docs/r/service_networking_connection.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "google"
+page_title: "Google: google_service_networking_connection"
+sidebar_current: "docs-google-service-networking-connection"
+description: |-
+  Manages creating a private VPC connection to a service provider.
+---
+
+# google\_service\_networking\_connection
+
+Manages a private VPC connection with a GCP service provider. For more information see
+[the official documentation](https://cloud.google.com/vpc/docs/configure-private-services-access#creating-connection)
+and
+[API](https://cloud.google.com/service-infrastructure/docs/service-networking/reference/rest/v1/services.connections).
+
+## Example usage
+
+```hcl
+resource "google_compute_network" "peering_network" {
+  name = "peering_network"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  name          = "private_ip_alloc"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = "${google_compute_network.peering_network.self_link}"
+}
+
+resource "google_service_networking_connection" "foobar" {
+  network                 = "${google_compute_network.peering_network.self_link}"
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = ["${google_compute_global_address.private_ip_alloc.name}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `network` - (Required) Name of VPC network connected with service producers using VPC peering.
+
+* `service` - (Required) Provider peering service that is managing peering connectivity for a
+  service provider organization. For Google services that support this functionality it is
+  'servicenetworking.googleapis.com'.
+
+* `reserved_peering_ranges` - (Required) Named IP address range(s) of PEERING type reserved for
+  this service provider. Note that invoking this method with a different range when connection
+  is already established will not reallocate already provisioned service producer subnetworks.

--- a/website/google.erb
+++ b/website/google.erb
@@ -607,6 +607,15 @@
     </ul>
     </li>
 
+    <li<%= sidebar_current("docs-google-service-networking") %>>
+    <a href="#">Google Service Networking Resources</a>
+    <ul class="nav nav-visible">
+      <li<%= sidebar_current("docs-google-service-networking-connection") %>>
+      <a href="/docs/providers/google/r/service_networking_connection.html">google_service_networking_connection</a>
+      </li>
+    </ul>
+    </li>
+
     <li<%= sidebar_current("docs-google-sourcerepo") %>>
     <a href="#">Google Source Repositories Resources</a>
     <ul class="nav nav-visible">


### PR DESCRIPTION
This PR provides support for the resource ServiceNetworking.Connection. This is in support of the private IP CloudSQL feature. 

(Note): The ServiceNetworking API is super out of band in that it severely deviates from the norms of the rest of the GCP API. I don't think as it stands this resource can be supported by MM.

Feature Issue: https://github.com/terraform-providers/terraform-provider-google/issues/2127
Related PR: https://github.com/terraform-providers/terraform-provider-google-beta/pull/46