### PR TITLE
Fix the breaking change in sqladmin.

### DIFF
--- a/google-beta/resource_sql_user.go
+++ b/google-beta/resource_sql_user.go
@@ -171,7 +171,7 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		mutexKV.Lock(instanceMutexKey(project, instance))
 		defer mutexKV.Unlock(instanceMutexKey(project, instance))
-		op, err := config.clientSqlAdmin.Users.Update(project, instance, host, name,
+		op, err := config.clientSqlAdmin.Users.Update(project, instance, name,
 			user).Do()
 
 		if err != nil {


### PR DESCRIPTION
This is the diff after running GoogleCloudPlatform/magic-modules#690.
We're applying it manually to fix the build, because the magician won't
pull the code to create this PR until the code can be built.