### PR TITLE
Update go versions used in development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - docker
 language: go
 go:
-- "1.11"
+- "1.11.x"
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To upgrade to the latest stable version of the Google provider run `terraform in
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.11.4+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 


### PR DESCRIPTION
Parallel to https://github.com/terraform-providers/terraform-provider-google/pull/2934