### PR TITLE
Add support for minCpuPlatform param in resourceDataprocCluster InstanceGroupConfig

### DIFF
--- a/google-beta/config.go
+++ b/google-beta/config.go
@@ -30,6 +30,7 @@ import (
 	containerBeta "google.golang.org/api/container/v1beta1"
 	dataflow "google.golang.org/api/dataflow/v1b3"
 	"google.golang.org/api/dataproc/v1"
+	dataprocBeta "google.golang.org/api/dataproc/v1beta2"
 	"google.golang.org/api/dns/v1"
 	dnsBeta "google.golang.org/api/dns/v1beta2"
 	file "google.golang.org/api/file/v1beta1"
@@ -73,6 +74,7 @@ type Config struct {
 	clientContainer              *container.Service
 	clientContainerBeta          *containerBeta.Service
 	clientDataproc               *dataproc.Service
+	clientDataprocBeta           *dataprocBeta.Service
 	clientDataflow               *dataflow.Service
 	clientDns                    *dns.Service
 	clientDnsBeta                *dnsBeta.Service
@@ -330,6 +332,13 @@ func (c *Config) LoadAndValidate() error {
 		return err
 	}
 	c.clientDataproc.UserAgent = userAgent
+
+	log.Printf("[INFO] Instantiating Google Cloud Dataproc Beta client...")
+	c.clientDataprocBeta, err = dataprocBeta.NewService(context, option.WithHTTPClient(client))
+	if err != nil {
+		return err
+	}
+	c.clientDataprocBeta.UserAgent = userAgent
 
 	c.clientFilestore, err = file.NewService(context, option.WithHTTPClient(client))
 	if err != nil {

--- a/google-beta/dataproc_cluster_operation.go
+++ b/google-beta/dataproc_cluster_operation.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 
-	"google.golang.org/api/dataproc/v1"
+	"google.golang.org/api/dataproc/v1beta2"
 )
 
 type DataprocClusterOperationWaiter struct {
@@ -20,7 +20,7 @@ func (w *DataprocClusterOperationWaiter) QueryOp() (interface{}, error) {
 
 func dataprocClusterOperationWait(config *Config, op *dataproc.Operation, activity string, timeoutMinutes int) error {
 	w := &DataprocClusterOperationWaiter{
-		Service: config.clientDataproc,
+		Service: config.clientDataprocBeta,
 	}
 	if err := w.SetOp(op); err != nil {
 		return err

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -319,7 +319,7 @@ The `cluster_config.worker_config` block supports:
    to create for the worker nodes. If not specified, GCP will default to a predetermined
    computed value (currently `n1-standard-4`).
 
-* `min_cpu_platform` - (Optional, Computed) The name of a minimum generation of CPU family
+* `min_cpu_platform` - (Optional, Computed, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The name of a minimum generation of CPU family
    for the master. If not specified, GCP will default to a predetermined computed value
    for each zone. See [the guide](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
    for details about which CPU families are available (and defaulted) for each zone.

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -256,7 +256,7 @@ The `cluster_config.master_config` block supports:
    to create for the master. If not specified, GCP will default to a predetermined
    computed value (currently `n1-standard-4`).
 
-* `min_cpu_platform` - (Optional, Computed) The name of a minimum generation of CPU family
+* `min_cpu_platform` - (Optional, Computed, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The name of a minimum generation of CPU family
    for the master. If not specified, GCP will default to a predetermined computed value
    for each zone. See [the guide](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
    for details about which CPU families are available (and defaulted) for each zone.

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -50,6 +50,7 @@ resource "google_dataproc_cluster" "mycluster" {
         worker_config {
             num_instances     = 2
             machine_type      = "n1-standard-1"
+            min_cpu_platform  = "Intel Skylake"
             disk_config {
                 boot_disk_size_gb = 15
                 num_local_ssds    = 1
@@ -238,6 +239,7 @@ The `cluster_config.master_config` block supports:
         master_config {
             num_instances     = 1
             machine_type      = "n1-standard-1"
+            min_cpu_platform  = "Intel Skylake"
             disk_config {
                 boot_disk_type    = "pd-ssd"
                 boot_disk_size_gb = 15
@@ -253,6 +255,11 @@ The `cluster_config.master_config` block supports:
 * `machine_type` - (Optional, Computed) The name of a Google Compute Engine machine type
    to create for the master. If not specified, GCP will default to a predetermined
    computed value (currently `n1-standard-4`).
+
+* `min_cpu_platform` - (Optional, Computed) The name of a minimum generation of CPU family
+   for the master. If not specified, GCP will default to a predetermined computed value
+   for each zone. See [the guide](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
+   for details about which CPU families are available (and defaulted) for each zone.
 
 * `image_uri` (Optional) The URI for the image to use for this worker.  See [the guide](https://cloud.google.com/dataproc/docs/guides/dataproc-images)
     for more information.
@@ -290,6 +297,7 @@ The `cluster_config.worker_config` block supports:
         worker_config {
             num_instances     = 3
             machine_type      = "n1-standard-1"
+            min_cpu_platform  = "Intel Skylake"
             disk_config {
                 boot_disk_type    = "pd-standard"
                 boot_disk_size_gb = 15
@@ -310,6 +318,11 @@ The `cluster_config.worker_config` block supports:
 * `machine_type` - (Optional, Computed) The name of a Google Compute Engine machine type
    to create for the worker nodes. If not specified, GCP will default to a predetermined
    computed value (currently `n1-standard-4`).
+
+* `min_cpu_platform` - (Optional, Computed) The name of a minimum generation of CPU family
+   for the master. If not specified, GCP will default to a predetermined computed value
+   for each zone. See [the guide](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
+   for details about which CPU families are available (and defaulted) for each zone.
 
 * `disk_config` (Optional) Disk Config
 


### PR DESCRIPTION
This is a new feature in the GCloud Beta client that lets you specify the CPU architecture for all nodes in each instance group.

This requires re-vendoring the actual released version of `google.golang.org/api` which I noticed is already open in #411 so I did not include it here because it obviously blows up the diff with tens of thousands of unrelated lines.

This has undergone manual testing on my own cluster and appears to work perfectly.

TODO
====
 - [x] Add reference to the new parameter in the documentation