### PR TITLE
use resource names that are allowed by GCP in example

### DIFF
--- a/website/docs/r/service_networking_connection.html.markdown
+++ b/website/docs/r/service_networking_connection.html.markdown
@@ -20,11 +20,11 @@ and
 
 ```hcl
 resource "google_compute_network" "peering_network" {
-  name = "peering_network"
+  name = "peering-network"
 }
 
 resource "google_compute_global_address" "private_ip_alloc" {
-  name          = "private_ip_alloc"
+  name          = "private-ip-alloc"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16


### PR DESCRIPTION
Running the example fails as the names used are not allowed by GCP.
Replacing _ with - fixes this