### PR TITLE
Add Support for Database Encryption

### DIFF
--- a/google-beta/bootstrap_utils_test.go
+++ b/google-beta/bootstrap_utils_test.go
@@ -18,9 +18,15 @@ type bootstrappedKMS struct {
 	*cloudkms.CryptoKey
 }
 
+// BootstrapKMSKey returns a KMS key in the "global" location.
+// See BootstrapKMSKeyInLocation.
+func BootstrapKMSKey(t *testing.T) bootstrappedKMS {
+	return BootstrapKMSKeyInLocation(t, "global")
+}
+
 /**
-* BootstrapKMSkey will return a KMS key that can be used in tests that are
-* testing KMS integration with other resources.
+* BootstrapKMSKeyWithLocation will return a KMS key in a particular location
+* that can be used in tests that are testing KMS integration with other resources.
 *
 * This will either return an existing key or create one if it hasn't been created
 * in the project yet. The motivation is because keyrings don't get deleted and we
@@ -28,7 +34,7 @@ type bootstrappedKMS struct {
 * to incur the overhead of creating a new project for each test that needs to use
 * a KMS key.
 **/
-func BootstrapKMSKey(t *testing.T) bootstrappedKMS {
+func BootstrapKMSKeyInLocation(t *testing.T, locationID string) bootstrappedKMS {
 	if v := os.Getenv("TF_ACC"); v == "" {
 		log.Println("Acceptance tests and bootstrapping skipped unless env 'TF_ACC' set")
 
@@ -40,7 +46,6 @@ func BootstrapKMSKey(t *testing.T) bootstrappedKMS {
 	}
 
 	projectID := getTestProjectFromEnv()
-	locationID := "global"
 	keyRingParent := fmt.Sprintf("projects/%s/locations/%s", projectID, locationID)
 	keyRingName := fmt.Sprintf("%s/keyRings/%s", keyRingParent, SharedKeyRing)
 	keyParent := fmt.Sprintf("projects/%s/locations/%s/keyRings/%s", projectID, locationID, SharedKeyRing)

--- a/google-beta/resource_container_cluster.go
+++ b/google-beta/resource_container_cluster.go
@@ -660,6 +660,29 @@ func resourceContainerCluster() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+
+			"database_encryption": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"state": {
+							Type:         schema.TypeString,
+							ForceNew:     true,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"ENCRYPTED", "DECRYPTED"}, false),
+						},
+						"key_name": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -799,6 +822,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("private_cluster_config"); ok {
 		cluster.PrivateClusterConfig = expandPrivateClusterConfig(v)
+	}
+
+	if v, ok := d.GetOk("database_encryption"); ok {
+		cluster.DatabaseEncryption = expandDatabaseEncryption(v)
 	}
 
 	req := &containerBeta.CreateClusterRequest{
@@ -966,6 +993,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if err := d.Set("pod_security_policy_config", flattenPodSecurityPolicyConfig(cluster.PodSecurityPolicyConfig)); err != nil {
+		return err
+	}
+
+	if err := d.Set("database_encryption", flattenDatabaseEncryption(cluster.DatabaseEncryption)); err != nil {
 		return err
 	}
 
@@ -1880,6 +1911,18 @@ func expandPrivateClusterConfig(configured interface{}) *containerBeta.PrivateCl
 	}
 }
 
+func expandDatabaseEncryption(configured interface{}) *containerBeta.DatabaseEncryption {
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
+	}
+	config := l[0].(map[string]interface{})
+	return &containerBeta.DatabaseEncryption{
+		State:   config["state"].(string),
+		KeyName: config["key_name"].(string),
+	}
+}
+
 func expandPodSecurityPolicyConfig(configured interface{}) *containerBeta.PodSecurityPolicyConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -2116,6 +2159,18 @@ func flattenPodSecurityPolicyConfig(c *containerBeta.PodSecurityPolicyConfig) []
 	return []map[string]interface{}{
 		{
 			"enabled": c.Enabled,
+		},
+	}
+}
+
+func flattenDatabaseEncryption(c *containerBeta.DatabaseEncryption) []map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+	return []map[string]interface{}{
+		{
+			"state":    c.State,
+			"key_name": c.KeyName,
 		},
 	}
 }

--- a/google-beta/resource_container_cluster_test.go
+++ b/google-beta/resource_container_cluster_test.go
@@ -1634,6 +1634,36 @@ func TestAccContainerCluster_errorNoClusterCreated(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withDatabaseEncryption(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+
+	// Use the bootstrapped KMS key so we can avoid creating keys needlessly
+	// as they will pile up in the project because they can not be completely
+	// deleted.  Also, we need to create the key in the same location as the
+	// cluster as GKE does not support the "global" location for KMS keys.
+	// See https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets#creating_a_key
+	kmsData := BootstrapKMSKeyInLocation(t, "us-central1")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withDatabaseEncryption(clusterName, kmsData),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_database_encryption",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func testAccCheckContainerClusterDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -3111,7 +3141,7 @@ resource "google_container_cluster" "with_flexible_cidr" {
 	}
 
 	master_authorized_networks_config { }
-	
+
 	ip_allocation_policy {
 		cluster_secondary_range_name  = "${google_compute_subnetwork.container_subnetwork.secondary_ip_range.0.range_name}"
 		services_secondary_range_name = "${google_compute_subnetwork.container_subnetwork.secondary_ip_range.1.range_name}"
@@ -3164,4 +3194,35 @@ resource "google_container_cluster" "with_resource_labels" {
 	initial_node_count = 1
 }
 `, location)
+}
+
+func testAccContainerCluster_withDatabaseEncryption(clusterName string, kmsData bootstrappedKMS) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {}
+
+data "google_iam_policy" "test_kms_binding" {
+  binding {
+    role = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+    members = [
+	  "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com",
+    ]
+  }
+}
+
+resource "google_kms_key_ring_iam_policy" "test_key_ring_iam_policy" {
+  key_ring_id = "%[1]s"
+  policy_data = "${data.google_iam_policy.test_kms_binding.policy_data}"
+}
+
+resource "google_container_cluster" "with_database_encryption" {
+	name = "cluster-test-%[3]s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+
+	database_encryption {
+		state = "ENCRYPTED"
+		key_name = "%[2]s"
+	}
+}`, kmsData.KeyRing.Name, kmsData.CryptoKey.Name, clusterName)
 }

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -181,6 +181,9 @@ deprecated in favour of `node_locations`.
 * `cluster_autoscaling` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html))
     Configuration for per-cluster autoscaling features, including node autoprovisioning. See [guide in Google docs](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning). Structure is documented below.
 
+* `database_encryption` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)).
+    Structure is documented below.
+
 * `description` - (Optional) Description of the cluster.
 
 * `default_max_pods_per_node` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The default maximum number of pods per node in this cluster.
@@ -343,6 +346,12 @@ addons_config {
   }
 }
 ```
+
+The `database_encryption` block supports:
+
+* `state` - (Required) `ENCRYPTED` or `DECRYPTED`
+
+* `key_name` - (Required) the key to use to encrypt/decrypt secrets.  See the [DatabaseEncryption definition](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.DatabaseEncryption) for more information.
 
 The `istio_config` block supports:
 


### PR DESCRIPTION
The goal of this PR is to add support for setting the [DatabaseEncryption](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.DatabaseEncryption) attributes in the container cluster resource.  It was necessary to upgrade the google api beyond version 0.1.0.  In the spirit of keeping things current, I elected to go with the latest released version, 0.4.0.  That also required changing the way the clients are instantiated in the configuration as the old method was deprecated.  Documentation has also been updated to include the new arguments.

Partially addresses terraform-providers/terraform-provider-google#3315

I'm happy to address any issues if you'd prefer this to be submitted differently.