### PR TITLE
Add support for setting gke intranode visibility

### DIFF
--- a/google-beta/resource_container_cluster_test.go
+++ b/google-beta/resource_container_cluster_test.go
@@ -606,6 +606,44 @@ func TestAccContainerCluster_withLegacyAbac(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withIntraNodeVisibility(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withIntraNodeVisibility(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_intranode_visibility", "enable_intranode_visibility", "true"),
+				),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_intranode_visibility",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_updateIntraNodeVisibility(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.with_intranode_visibility", "enable_intranode_visibility", "false"),
+				),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_intranode_visibility",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 /*
 	Since GKE disables legacy ABAC by default in Kubernetes version 1.8+, and the default Kubernetes
 	version for GKE is also 1.8+, this test will ensure that legacy ABAC is disabled by default to be
@@ -627,6 +665,34 @@ func TestAccContainerCluster_withDefaultLegacyAbac(t *testing.T) {
 			},
 			{
 				ResourceName:        "google_container_cluster.default_legacy_abac",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+/*
+	Since GKE disables Intra Node Visibility by default, this test will ensure that Intra Node Visibility is disabled by default to be
+	more consistent with default settings in the Cloud Console
+*/
+func TestAccContainerCluster_withDefaultIntraNodeVisibility(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_defaultIntraNodeVisibility(acctest.RandString(10)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_cluster.default_intranode_visibility", "enable_intranode_visibility", "false"),
+				),
+			},
+			{
+				ResourceName:        "google_container_cluster.default_intranode_visibility",
 				ImportStateIdPrefix: "us-central1-a/",
 				ImportState:         true,
 				ImportStateVerify:   true,
@@ -2200,6 +2266,37 @@ resource "google_container_cluster" "with_legacy_abac" {
 	initial_node_count = 1
 
 	enable_legacy_abac = false
+}`, clusterName)
+}
+
+func testAccContainerCluster_defaultIntraNodeVisibility(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "default_intranode_visibility" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+}`, clusterName)
+}
+
+func testAccContainerCluster_withIntraNodeVisibility(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_intranode_visibility" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+
+	enable_intranode_visibility = true
+}`, clusterName)
+}
+
+func testAccContainerCluster_updateIntraNodeVisibility(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_intranode_visibility" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+
+	enable_intranode_visibility = false
 }`, clusterName)
 }
 


### PR DESCRIPTION
This PR adds the option to set [GKE intranode visibility](https://cloud.google.com/kubernetes-engine/docs/how-to/intranode-visibility). 
Intranode Visibility is a beta option available on GKE clusters versions >= 1.11 and set to false by default.

Both tests report a pass and I also confirmed the behaviour on the GCP console while the tests were running as well as via the GCP Audit Logs.

```
$ make testacc TEST=./google-beta TESTARGS='-run=TestAccContainerCluster_withDefaultIntraNodeVisibility'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -v -run=TestAccContainerCluster_withDefaultIntraNodeVisibility -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-google-beta/version.ProviderVersion=acc"
=== RUN   TestAccContainerCluster_withDefaultIntraNodeVisibility
=== PAUSE TestAccContainerCluster_withDefaultIntraNodeVisibility
=== CONT  TestAccContainerCluster_withDefaultIntraNodeVisibility
--- PASS: TestAccContainerCluster_withDefaultIntraNodeVisibility (525.36s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google-beta/google-beta	525.390s
```


```
$ make testacc TEST=./google-beta TESTARGS='-run=TestAccContainerCluster_withIntraNodeVisibility'
==> Checking source code against gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test ./google-beta -v -run=TestAccContainerCluster_withIntraNodeVisibility -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-google-beta/version.ProviderVersion=acc"
=== RUN   TestAccContainerCluster_withIntraNodeVisibility
=== PAUSE TestAccContainerCluster_withIntraNodeVisibility
=== CONT  TestAccContainerCluster_withIntraNodeVisibility
--- PASS: TestAccContainerCluster_withIntraNodeVisibility (868.51s)
PASS
ok  	github.com/terraform-providers/terraform-provider-google-beta/google-beta	868.542s