### PR TITLE
Allow updating workload identity in GKE clusters without force create

### DIFF
--- a/google-beta/resource_container_cluster_test.go
+++ b/google-beta/resource_container_cluster_test.go
@@ -1316,6 +1316,33 @@ func TestAccContainerCluster_withWorkloadIdentityConfig(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 			},
+			{
+				Config: testAccContainerCluster_updateWorkloadMetadataConfig(pid, clusterName, "SECURE"),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_updateWorkloadIdentityConfig(pid, clusterName, false),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_updateWorkloadIdentityConfig(pid, clusterName, true),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 
@@ -2215,6 +2242,30 @@ resource "google_container_cluster" "with_workload_metadata_config" {
 `, acctest.RandString(10))
 }
 
+func testAccContainerCluster_updateWorkloadMetadataConfig(projectID string, clusterName string, workloadMetadataConfig string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {
+	project_id = "%s"
+}
+
+resource "google_container_cluster" "with_workload_identity_config" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+
+  node_config {
+		oauth_scopes = [
+			"https://www.googleapis.com/auth/logging.write",
+			"https://www.googleapis.com/auth/monitoring"
+		]
+
+		workload_metadata_config {
+			node_metadata = "%s"
+		}
+  }
+}`, projectID, clusterName, workloadMetadataConfig)
+}
+
 func testAccContainerCluster_withSandboxConfig() string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
@@ -2932,6 +2983,28 @@ resource "google_container_cluster" "with_workload_identity_config" {
 	}
 }
 `, projectID, clusterName)
+}
+
+func testAccContainerCluster_updateWorkloadIdentityConfig(projectID string, clusterName string, enable bool) string {
+	workloadIdentityConfig := ""
+	if enable {
+		workloadIdentityConfig = `
+			workload_identity_config {
+			identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
+		}`
+	}
+	return fmt.Sprintf(`
+data "google_project" "project" {
+	project_id = "%s"
+}
+
+resource "google_container_cluster" "with_workload_identity_config" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+
+	%s
+}`, projectID, clusterName, workloadIdentityConfig)
 }
 
 func testAccContainerCluster_withBinaryAuthorization(clusterName string, enabled bool) string {


### PR DESCRIPTION
Since gcloud allows updating workload identity from console and sdk without recreating the cluster, terraform also should not force recreation.

I have tested it locally with this change, it worked fine for me without recreating the cluster.