### PR TITLE
Add global access for internal load balancers

### DIFF
--- a/google-beta/resource_compute_forwarding_rule.go
+++ b/google-beta/resource_compute_forwarding_rule.go
@@ -282,7 +282,7 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
         if err != nil {
                 return err
         } else if v, ok := d.GetOkExists("allow_global_access"); !isEmptyValue(reflect.ValueOf(allowGlobalAccessProp)) && (ok || !reflect.DeepEqual(v, allowGlobalAccessProp)) {
-                obj["allowGlobalAccess"] = allGlobalAccessProp
+                obj["allowGlobalAccess"] = allowGlobalAccessProp
         }
 	networkTierProp, err := expandComputeForwardingRuleNetworkTier(d.Get("network_tier"), d, config)
 	if err != nil {
@@ -704,6 +704,10 @@ func flattenComputeForwardingRuleAllPorts(v interface{}, d *schema.ResourceData)
 	return v
 }
 
+func flattenComputeForwardingRuleAllowGlobalAccess(v interface{}, d *schema.ResourceData) interface{} {
+	return v
+}
+
 func flattenComputeForwardingRuleNetworkTier(v interface{}, d *schema.ResourceData) interface{} {
 	return v
 }
@@ -845,6 +849,10 @@ func expandComputeForwardingRuleLabelFingerprint(v interface{}, d TerraformResou
 }
 
 func expandComputeForwardingRuleAllPorts(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandComputeForwardingRuleAllowGlobalAccess(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/google-beta/resource_compute_forwarding_rule.go
+++ b/google-beta/resource_compute_forwarding_rule.go
@@ -68,6 +68,11 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"allow_global_access": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 			"backend_service": {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -273,6 +278,12 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 	} else if v, ok := d.GetOkExists("all_ports"); !isEmptyValue(reflect.ValueOf(allPortsProp)) && (ok || !reflect.DeepEqual(v, allPortsProp)) {
 		obj["allPorts"] = allPortsProp
 	}
+        allowGlobalAccessProp, err := expandComputeForwardingRuleAllowGlobalAccess(d.Get("allow_global_access"), d, config)
+        if err != nil {
+                return err
+        } else if v, ok := d.GetOkExists("allow_global_access"); !isEmptyValue(reflect.ValueOf(allowGlobalAccessProp)) && (ok || !reflect.DeepEqual(v, allowGlobalAccessProp)) {
+                obj["allowGlobalAccess"] = allGlobalAccessProp
+        }
 	networkTierProp, err := expandComputeForwardingRuleNetworkTier(d.Get("network_tier"), d, config)
 	if err != nil {
 		return err
@@ -445,6 +456,9 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("all_ports", flattenComputeForwardingRuleAllPorts(res["allPorts"], d)); err != nil {
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}
+        if err := d.Set("allow_global_access", flattenComputeForwardingRuleAllowGlobalAccess(res["allowGlobalAccess"], d)); err != nil {
+                return fmt.Errorf("Error reading ForwardingRule: %s", err)
+        }
 	if err := d.Set("network_tier", flattenComputeForwardingRuleNetworkTier(res["networkTier"], d)); err != nil {
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}

--- a/google-beta/resource_compute_forwarding_rule.go
+++ b/google-beta/resource_compute_forwarding_rule.go
@@ -278,12 +278,12 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 	} else if v, ok := d.GetOkExists("all_ports"); !isEmptyValue(reflect.ValueOf(allPortsProp)) && (ok || !reflect.DeepEqual(v, allPortsProp)) {
 		obj["allPorts"] = allPortsProp
 	}
-        allowGlobalAccessProp, err := expandComputeForwardingRuleAllowGlobalAccess(d.Get("allow_global_access"), d, config)
-        if err != nil {
-                return err
-        } else if v, ok := d.GetOkExists("allow_global_access"); !isEmptyValue(reflect.ValueOf(allowGlobalAccessProp)) && (ok || !reflect.DeepEqual(v, allowGlobalAccessProp)) {
-                obj["allowGlobalAccess"] = allowGlobalAccessProp
-        }
+	allowGlobalAccessProp, err := expandComputeForwardingRuleAllowGlobalAccess(d.Get("allow_global_access"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("allow_global_access"); !isEmptyValue(reflect.ValueOf(allowGlobalAccessProp)) && (ok || !reflect.DeepEqual(v, allowGlobalAccessProp)) {
+		obj["allowGlobalAccess"] = allowGlobalAccessProp
+	}
 	networkTierProp, err := expandComputeForwardingRuleNetworkTier(d.Get("network_tier"), d, config)
 	if err != nil {
 		return err
@@ -456,9 +456,9 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("all_ports", flattenComputeForwardingRuleAllPorts(res["allPorts"], d)); err != nil {
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}
-        if err := d.Set("allow_global_access", flattenComputeForwardingRuleAllowGlobalAccess(res["allowGlobalAccess"], d)); err != nil {
-                return fmt.Errorf("Error reading ForwardingRule: %s", err)
-        }
+	if err := d.Set("allow_global_access", flattenComputeForwardingRuleAllowGlobalAccess(res["allowGlobalAccess"], d)); err != nil {
+		return fmt.Errorf("Error reading ForwardingRule: %s", err)
+	}
 	if err := d.Set("network_tier", flattenComputeForwardingRuleNetworkTier(res["networkTier"], d)); err != nil {
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}

--- a/google-beta/resource_compute_forwarding_rule_test.go
+++ b/google-beta/resource_compute_forwarding_rule_test.go
@@ -63,6 +63,37 @@ func TestAccComputeForwardingRule_ip(t *testing.T) {
 	})
 }
 
+func TestAccComputeForwardingRule_internalLoadBalancing(t *testing.T) {
+        t.Parallel()
+
+        serviceName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+        checkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+        networkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+        ruleName1 := fmt.Sprintf("tf-%s", acctest.RandString(10))
+        ruleName2 := fmt.Sprintf("tf-%s", acctest.RandString(10))
+
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckComputeForwardingRuleDestroy,
+                Steps: []resource.TestStep{
+                        {
+                                Config: testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2),
+                        },
+                        {
+                                ResourceName:      "google_compute_forwarding_rule.foobar",
+                                ImportState:       true,
+                                ImportStateVerify: true,
+                        },
+                        {
+                                ResourceName:      "google_compute_forwarding_rule.foobar2",
+                                ImportState:       true,
+                                ImportStateVerify: true,
+                        },
+                },
+        })
+}
+
 func TestAccComputeForwardingRule_networkTier(t *testing.T) {
 	t.Parallel()
 
@@ -111,7 +142,7 @@ resource "google_compute_target_pool" "foo-tp" {
   description = "Resource created for Terraform acceptance testing"
   instances   = ["us-central1-a/foo", "us-central1-b/bar"]
   name        = "foo-%s"
-}
+}	
 resource "google_compute_target_pool" "bar-tp" {
   description = "Resource created for Terraform acceptance testing"
   instances   = ["us-central1-a/foo", "us-central1-b/bar"]
@@ -147,6 +178,57 @@ resource "google_compute_forwarding_rule" "foobar" {
   target      = "${google_compute_target_pool.foobar-tp.self_link}"
 }
 `, addrName, poolName, ruleName)
+}
+
+func testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2 string) string {
+        return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar-bs" {
+  name                  = "%s"
+  description           = "Resource created for Terraform acceptance testing"
+  health_checks         = ["${google_compute_health_check.zero.self_link}"]
+  region                = "us-central1"
+}
+resource "google_compute_health_check" "zero" {
+  name               = "%s"
+  description        = "Resource created for Terraform acceptance testing"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = "80"
+  }
+}
+resource "google_compute_network" "foobar" {
+  name = "%s"
+  auto_create_subnetworks = true
+}
+resource "google_compute_forwarding_rule" "foobar" {
+  description           = "Resource created for Terraform acceptance testing"
+  name                  = "%s"
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = "${google_compute_region_backend_service.foobar-bs.self_link}"
+  all_ports             = true
+  network               = "${google_compute_network.foobar.name}"
+  subnetwork            = "%s"
+}
+resource "google_compute_forwarding_rule" "foobar2" {
+  description           = "Resource created for Terraform acceptance testing"
+  name                  = "%s"
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = "${google_compute_region_backend_service.foobar-bs.self_link}"
+  ports                 = ["80"]
+  network               = "${google_compute_network.foobar.self_link}"
+}
+resource "google_compute_forwarding_rule" "foobar3" {
+  description           = "Resource created for Terraform acceptance testing"
+  name                  = "%s"
+  load_balancing_scheme = "INTERNAL"
+  backend_service       = "${google_compute_region_backend_service.foobar-bs.self_link}"
+  allow_global_access   = true
+  network               = "${google_compute_network.foobar.name}"
+  subnetwork            = "%s"
+}
+`, serviceName, checkName, networkName, ruleName1, networkName, ruleName2)
 }
 
 func testAccComputeForwardingRule_networkTier(poolName, ruleName string) string {

--- a/google-beta/resource_compute_forwarding_rule_test.go
+++ b/google-beta/resource_compute_forwarding_rule_test.go
@@ -142,7 +142,7 @@ resource "google_compute_target_pool" "foo-tp" {
   description = "Resource created for Terraform acceptance testing"
   instances   = ["us-central1-a/foo", "us-central1-b/bar"]
   name        = "foo-%s"
-}	
+}
 resource "google_compute_target_pool" "bar-tp" {
   description = "Resource created for Terraform acceptance testing"
   instances   = ["us-central1-a/foo", "us-central1-b/bar"]

--- a/google-beta/resource_compute_forwarding_rule_test.go
+++ b/google-beta/resource_compute_forwarding_rule_test.go
@@ -181,7 +181,7 @@ resource "google_compute_forwarding_rule" "foobar" {
 `, addrName, poolName, ruleName)
 }
 
-func testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2 string) string {
+func testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2, ruleName3 string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar-bs" {
   name                  = "%s"
@@ -229,7 +229,7 @@ resource "google_compute_forwarding_rule" "foobar3" {
   network               = "${google_compute_network.foobar.name}"
   subnetwork            = "%s"
 }
-`, serviceName, checkName, networkName, ruleName1, networkName, ruleName2)
+`, serviceName, checkName, networkName, ruleName1, networkName, ruleName2, ruleName3, networkName)
 }
 
 func testAccComputeForwardingRule_networkTier(poolName, ruleName string) string {

--- a/google-beta/resource_compute_forwarding_rule_test.go
+++ b/google-beta/resource_compute_forwarding_rule_test.go
@@ -71,6 +71,7 @@ func TestAccComputeForwardingRule_internalLoadBalancing(t *testing.T) {
 	networkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	ruleName1 := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	ruleName2 := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	ruleName3 := fmt.Sprintf("tf-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -78,7 +79,7 @@ func TestAccComputeForwardingRule_internalLoadBalancing(t *testing.T) {
 		CheckDestroy: testAccCheckComputeForwardingRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2),
+				Config: testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2, ruleName3),
 			},
 			{
 				ResourceName:      "google_compute_forwarding_rule.foobar",

--- a/google-beta/resource_compute_forwarding_rule_test.go
+++ b/google-beta/resource_compute_forwarding_rule_test.go
@@ -64,34 +64,34 @@ func TestAccComputeForwardingRule_ip(t *testing.T) {
 }
 
 func TestAccComputeForwardingRule_internalLoadBalancing(t *testing.T) {
-        t.Parallel()
+	t.Parallel()
 
-        serviceName := fmt.Sprintf("tf-%s", acctest.RandString(10))
-        checkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
-        networkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
-        ruleName1 := fmt.Sprintf("tf-%s", acctest.RandString(10))
-        ruleName2 := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	serviceName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	networkName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	ruleName1 := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	ruleName2 := fmt.Sprintf("tf-%s", acctest.RandString(10))
 
-        resource.Test(t, resource.TestCase{
-                PreCheck:     func() { testAccPreCheck(t) },
-                Providers:    testAccProviders,
-                CheckDestroy: testAccCheckComputeForwardingRuleDestroy,
-                Steps: []resource.TestStep{
-                        {
-                                Config: testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2),
-                        },
-                        {
-                                ResourceName:      "google_compute_forwarding_rule.foobar",
-                                ImportState:       true,
-                                ImportStateVerify: true,
-                        },
-                        {
-                                ResourceName:      "google_compute_forwarding_rule.foobar2",
-                                ImportState:       true,
-                                ImportStateVerify: true,
-                        },
-                },
-        })
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeForwardingRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2),
+			},
+			{
+				ResourceName:      "google_compute_forwarding_rule.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_compute_forwarding_rule.foobar2",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
 func TestAccComputeForwardingRule_networkTier(t *testing.T) {
@@ -181,7 +181,7 @@ resource "google_compute_forwarding_rule" "foobar" {
 }
 
 func testAccComputeForwardingRule_internalLoadBalancing(serviceName, checkName, networkName, ruleName1, ruleName2 string) string {
-        return fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar-bs" {
   name                  = "%s"
   description           = "Resource created for Terraform acceptance testing"

--- a/website/docs/r/compute_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_forwarding_rule.html.markdown
@@ -241,6 +241,12 @@ The following arguments are supported:
   with this forwarding rule. Used with backend service. Cannot be set
   if port or portRange are set.
 
+* `allow_global_access` -
+  (Optional)
+  For internal TCP/UDP load balancing (i.e. load balancing scheme is
+  INTERNAL and protocol is TCP/UDP), set this to true to allow traffic
+  from within the same network, regardless of region or subnetwork.
+
 * `network_tier` -
   (Optional)
   The networking tier used for configuring this address. This field can


### PR DESCRIPTION
Allow traffic from within the same network, regardless of region or subnetwork, for internal TCP/UDP load balancers.