### PR TITLE
Fix broken link in google_container_cluster docs

### DIFF
--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -667,7 +667,7 @@ exported:
     notation (e.g. `1.2.3.4/29`).
 
 * `services_ipv4_cidr` - The IP address range of the Kubernetes services in this
-  cluster, in [CIDR](http:en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
+  cluster, in [CIDR](http://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
   notation (e.g. `1.2.3.4/29`). Service addresses are typically put in the last
   `/16` from the container CIDR.
 


### PR DESCRIPTION
Missing `//` after `http:`.