### PR TITLE
No force new when changing resource_policies

### DIFF
--- a/google-beta/resource_compute_disk.go
+++ b/google-beta/resource_compute_disk.go
@@ -299,7 +299,6 @@ func resourceComputeDisk() *schema.Resource {
 			"resource_policies": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
 					DiffSuppressFunc: compareSelfLinkOrResourceName,

--- a/google-beta/resource_compute_disk.go
+++ b/google-beta/resource_compute_disk.go
@@ -758,12 +758,12 @@ func resourceComputeDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if d.HasChange("resource_policies") {
 		obj := make(map[string]interface{})
-    resourcePoliciesProp, err := expandComputeDiskResourcePolicies(d.Get("resource_policies"), d, config)
-  	if err != nil {
-  		return err
-  	} else if v, ok := d.GetOkExists("resource_policies"); !isEmptyValue(reflect.ValueOf(resourcePoliciesProp)) && (ok || !reflect.DeepEqual(v, resourcePoliciesProp)) {
-  		obj["resourcePolicies"] = resourcePoliciesProp
-  	}
+		resourcePoliciesProp, err := expandComputeDiskResourcePolicies(d.Get("resource_policies"), d, config)
+		if err != nil {
+			return err
+		} else if v, ok := d.GetOkExists("resource_policies"); !isEmptyValue(reflect.ValueOf(resourcePoliciesProp)) && (ok || !reflect.DeepEqual(v, resourcePoliciesProp)) {
+			obj["resourcePolicies"] = resourcePoliciesProp
+		}
 
 		url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/disks/{{name}}/addResourcePolicies")
 		if err != nil {


### PR DESCRIPTION
There is no need to force recreate compute disk when resource_policies is changed.