### PR TITLE
Allow updating resource_policies without recreation

### DIFF
--- a/google-beta/resource_compute_disk.go
+++ b/google-beta/resource_compute_disk.go
@@ -299,7 +299,6 @@ func resourceComputeDisk() *schema.Resource {
 			"resource_policies": {
 				Type:     schema.TypeList,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:             schema.TypeString,
 					DiffSuppressFunc: compareSelfLinkOrResourceName,

--- a/google-beta/resource_compute_disk.go
+++ b/google-beta/resource_compute_disk.go
@@ -758,12 +758,12 @@ func resourceComputeDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if d.HasChange("resource_policies") {
 		obj := make(map[string]interface{})
-    resourcePoliciesProp, err := expandComputeDiskResourcePolicies(d.Get("resource_policies"), d, config)
-  	if err != nil {
-  		return err
-  	} else if v, ok := d.GetOkExists("resource_policies"); !isEmptyValue(reflect.ValueOf(resourcePoliciesProp)) && (ok || !reflect.DeepEqual(v, resourcePoliciesProp)) {
-  		obj["resourcePolicies"] = resourcePoliciesProp
-  	}
+		resourcePoliciesProp, err := expandComputeDiskResourcePolicies(d.Get("resource_policies"), d, config)
+		if err != nil {
+			return err
+		} else if v, ok := d.GetOkExists("resource_policies"); !isEmptyValue(reflect.ValueOf(resourcePoliciesProp)) && (ok || !reflect.DeepEqual(v, resourcePoliciesProp)) {
+			obj["resourcePolicies"] = resourcePoliciesProp
+		}
 
 		url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/disks/{{name}}/addResourcePolicies")
 		if err != nil {


### PR DESCRIPTION
This PR allows updates to `resource_policies` property without requiring the resource to be force recreated.

- [x] Acceptance test coverage of new behavior: Added a test for update of resource policies
- [x] Documentation updates: not necessary as there are sufficient documentation from https://github.com/terraform-providers/terraform-provider-google-beta/pull/960
- [x] Well-formed Code: It is following `go fmt`