### PR TITLE
Fix compute_resource_policy schedule docs

### DIFF
--- a/website/docs/r/compute_resource_policy.html.markdown
+++ b/website/docs/r/compute_resource_policy.html.markdown
@@ -130,7 +130,7 @@ The `snapshot_schedule_policy` block supports:
 
 * `schedule` -
   (Required)
-  Contains one of an `hourlySchedule`, `dailySchedule`, or `weeklySchedule`.  Structure is documented below.
+  Contains one of an `hourly_schedule`, `daily_schedule`, or `weekly_schedule`.  Structure is documented below.
 
 * `retention_policy` -
   (Optional)


### PR DESCRIPTION
Changed the names of the items inside the schedule block to reflect what's described in the structure that's documented below