### PR TITLE
resource/compute_instance_template: Decorate name_prefix with ConflictsWith

### DIFF
--- a/google-beta/resource_compute_instance_template.go
+++ b/google-beta/resource_compute_instance_template.go
@@ -37,10 +37,11 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 			},
 
 			"name_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name"},
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					// https://cloud.google.com/compute/docs/reference/latest/instanceTemplates#resource
 					// uuid is 26 characters, limit the prefix to 37.

--- a/website/docs/r/compute_instance_template.html.markdown
+++ b/website/docs/r/compute_instance_template.html.markdown
@@ -190,7 +190,7 @@ The following arguments are supported:
 
 - - -
 * `name` - (Optional) The name of the instance template. If you leave
-  this blank, Terraform will auto-generate a unique name.
+  this blank, Terraform will auto-generate a unique name. Conflicts with `name_prefix`.
 
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified
   prefix. Conflicts with `name`.


### PR DESCRIPTION
When fields are conflicting, it seems it's normal to mark both fields
with the corresponding `ConflictsWith` schema decoration

We can see an example of this in AWS - https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_lb_target_group.go#L42-L56

We can see another example of this in Azure - https://github.com/terraform-providers/terraform-provider-azurerm/blob/b92a6a10f1e4fb90818861f4ed765b1499023712/azurerm/resource_arm_network_security_rule.go#L73-L91

And even in other google-beta resources - https://github.com/terraform-providers/terraform-provider-google-beta/blob/master/google-beta/resource_runtimeconfig_variable.go#L42-L52