### PR TITLE
Use vendored modules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ services:
 language: go
 go:
 - "1.13.x"
-env:
-  - GO111MODULE=on
-    GOFLAGS=-mod=vendor
 
 install:
 # This script is used by the Travis build to install a cookie for

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,8 +34,8 @@ lint:
 
 tools:
 	@echo "==> installing required tooling..."
-	GO111MODULE=on go install github.com/client9/misspell/cmd/misspell
-	GO111MODULE=on go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	go install github.com/client9/misspell/cmd/misspell
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,9 @@ WEBSITE_REPO=github.com/hashicorp/terraform-website
 PKG_NAME=google
 DIR_NAME=google-beta
 
+GO111MODULE=on
+GOFLAGS=-mod=vendor
+
 default: build
 
 build: fmtcheck


### PR DESCRIPTION
Set the proper environment variables to use the modules in our vendor dir instead of downloading them again.