### PR TITLE
Add 3.0.0-beta.1 to upgrade guide, note that 3.0.0 isn't out

### DIFF
--- a/website/docs/guides/version_3_upgrade.html.markdown
+++ b/website/docs/guides/version_3_upgrade.html.markdown
@@ -8,6 +8,11 @@ description: |-
 
 # Terraform Google Provider 3.0.0 Upgrade Guide
 
+-> `3.0.0` is not published yet. This guide was published beforehand to allow
+you to use it to help identify changes early, or resolve deprecation warnings in
+Terraform config. `3.0.0-beta.1` is currently available which allows you to test
+your changes prior to the full release.
+
 The `3.0.0` release of the Google provider for Terraform is a major version and
 includes some changes that you will need to consider when upgrading. This guide
 is intended to help with that process and focuses only on the changes necessary
@@ -19,6 +24,23 @@ releases, up to and including the final `2.X` series release. These changes,
 such as deprecation notices, can always be found in the CHANGELOG of the
 affected providers. [google](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md)
 [google-beta](https://github.com/terraform-providers/terraform-provider-google-beta/blob/master/CHANGELOG.md)
+
+## What is `3.0.0-beta.1`?
+
+With `3.0.0`, we introduced a prerelease window for our major provider releases.
+`3.0.0-beta.1` contains all of the changes in `3.0.0`, and allows you to test it
+prior to the full upgrade. Currently `3.0.0` is not expected to contain new
+features not available in `3.0.0-beta.1`, only bugfixes for issues we're made
+aware of before `3.0.0`'s release. Using `3.0.0-beta.1` in production is not
+recommended.
+
+```hcl
+provider "google" {
+  # ... other configuration ...
+
+  version = "~> 3.0.0-beta.1"
+}
+```
 
 ## I accidentally upgraded to 3.0.0, how do I downgrade to `2.X`?
 
@@ -144,6 +166,9 @@ provider "google" {
   version = "~> 2.17.0"
 }
 ```
+
+!> `3.0.0` is not available yet. You can use `3.0.0-beta.1` if you'd like to try
+out the changes beforehand.
 
 An updated configuration:
 


### PR DESCRIPTION
From https://googlecloud-community.slack.com/archives/C1VNJ4EG7/p1573825801054400

PRing directly against `stable-website` so the infoboxes go away on our next release, I'll pull the "What is `3.0.0-beta.1` block into MM / `master`.