### PR TITLE
Add support for peering_name attribute

### DIFF
--- a/google-beta/resource_container_cluster.go
+++ b/google-beta/resource_container_cluster.go
@@ -736,6 +736,10 @@ func resourceContainerCluster() *schema.Resource {
 							ForceNew:     true,
 							ValidateFunc: orEmpty(validation.CIDRNetwork(28, 28)),
 						},
+						"peering_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"private_endpoint": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -2500,6 +2504,7 @@ func flattenPrivateClusterConfig(c *containerBeta.PrivateClusterConfig) []map[st
 			"enable_private_endpoint": c.EnablePrivateEndpoint,
 			"enable_private_nodes":    c.EnablePrivateNodes,
 			"master_ipv4_cidr_block":  c.MasterIpv4CidrBlock,
+			"peering_name":            c.PeeringName,
 			"private_endpoint":        c.PrivateEndpoint,
 			"public_endpoint":         c.PublicEndpoint,
 		},

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -597,6 +597,8 @@ for more details. This field only applies to private clusters, when
 
 In addition, the `private_cluster_config` allows access to the following read-only fields:
 
+* `peering_name` - The name of the peering between this cluster and the Google owned VPC.
+
 * `private_endpoint` - The internal IP address of this cluster's master endpoint.
 
 * `public_endpoint` - The external IP address of this cluster's master endpoint.


### PR DESCRIPTION
- Missing a read-only attribute for the unique identifier `peeringName` that GKE generates after a cluster has been created.
- Required for private routing: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#master-on-prem-routing