### PR TITLE
Fix broken indents by nested list bullets

### DIFF
--- a/website/docs/r/bigquery_dataset.html.markdown
+++ b/website/docs/r/bigquery_dataset.html.markdown
@@ -201,9 +201,7 @@ The `access` block supports:
 
 * `special_group` -
   (Optional)
-  A special group to grant access to.
-
-  Possible values include:
+  A special group to grant access to. Possible values include:
 
   * `projectOwners`: Owners of the enclosing project.
 


### PR DESCRIPTION
I've just found a broken indents arround a section relates to `access` block in `bigquery_dataset.html.markdown` file :raising_hand_woman: 

### Problem

Current website shows the section like below. This may be a bit confusing:

![current-website-has-bit-weird-indents-20191203](https://user-images.githubusercontent.com/163063/70042255-e6223000-1601-11ea-8daf-3ac36b9307d9.png)

Although it looks fine on GitHub...

<details>
<summary>On GitHub</summary>

![on-github-markdown-seems-fine-20191203](https://user-images.githubusercontent.com/163063/70042281-f0442e80-1601-11ea-9535-7e4e621e1877.png)
</details>

### Fix

Then, I've just removed a line break before a paragraph by https://github.com/terraform-providers/terraform-provider-google-beta/commit/18160d598f3a26b57a65d5dd3bdc00980dbae16e.
\# I've checked the markdown rendering using [redcarpet](https://github.com/vmg/redcarpet) on local.

###### Before

<details>
<summary>Rendering result</summary>

![rendering-result-before-this-change-20191203](https://user-images.githubusercontent.com/163063/70042471-41542280-1602-11ea-850f-a39ea60a30f2.png)
</details>

###### After

<details>
<summary>Rendering result</summary>

![rendering-result-by-this-change-20191203](https://user-images.githubusercontent.com/163063/70042333-fcc88700-1601-11ea-941d-36dac2498363.png)
</details>

I hope that it works.
