### PR TITLE
Feature/packet mirror forward rule

### DIFF
--- a/google-beta/resource_compute_forwarding_rule.go
+++ b/google-beta/resource_compute_forwarding_rule.go
@@ -287,6 +287,11 @@ This field is only used for INTERNAL load balancing.`,
 				Computed: true,
 				ForceNew: true,
 			},
+			"mirroring": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 			"self_link": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -382,6 +387,12 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 		return err
 	} else if v, ok := d.GetOkExists("all_ports"); !isEmptyValue(reflect.ValueOf(allPortsProp)) && (ok || !reflect.DeepEqual(v, allPortsProp)) {
 		obj["allPorts"] = allPortsProp
+	}
+	mirroringProp, err := expandComputeForwardingRuleMirroring(d.Get("mirroring"), d, config)
+	if err != nil {
+		return err
+	} else if v, ok := d.GetOkExists("mirroring"); !isEmptyValue(reflect.ValueOf(mirroringProp)) && (ok || !reflect.DeepEqual(v, mirroringProp)) {
+		obj["isMirroringCollector"] = mirroringProp
 	}
 	networkTierProp, err := expandComputeForwardingRuleNetworkTier(d.Get("network_tier"), d, config)
 	if err != nil {
@@ -913,6 +924,10 @@ func expandComputeForwardingRuleLabelFingerprint(v interface{}, d TerraformResou
 }
 
 func expandComputeForwardingRuleAllPorts(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}
+
+func expandComputeForwardingRuleMirroring(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 

--- a/google-beta/resource_compute_forwarding_rule.go
+++ b/google-beta/resource_compute_forwarding_rule.go
@@ -287,10 +287,13 @@ This field is only used for INTERNAL load balancing.`,
 				Computed: true,
 				ForceNew: true,
 			},
-			"mirroring": {
+			"mirroring_collector": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
+				Description: `For internal TCP/UDP load balancing (i.e. load balancing scheme is
+					INTERNAL and protocol is TCP/UDP), set this to true to allow mirrored packets
+					to be sent to the forwarder.`,
 			},
 			"self_link": {
 				Type:     schema.TypeString,
@@ -388,10 +391,10 @@ func resourceComputeForwardingRuleCreate(d *schema.ResourceData, meta interface{
 	} else if v, ok := d.GetOkExists("all_ports"); !isEmptyValue(reflect.ValueOf(allPortsProp)) && (ok || !reflect.DeepEqual(v, allPortsProp)) {
 		obj["allPorts"] = allPortsProp
 	}
-	mirroringProp, err := expandComputeForwardingRuleMirroring(d.Get("mirroring"), d, config)
+	mirroringProp, err := expandComputeForwardingRuleMirroring(d.Get("mirroring_collector"), d, config)
 	if err != nil {
 		return err
-	} else if v, ok := d.GetOkExists("mirroring"); !isEmptyValue(reflect.ValueOf(mirroringProp)) && (ok || !reflect.DeepEqual(v, mirroringProp)) {
+	} else if v, ok := d.GetOkExists("mirroring_collector"); !isEmptyValue(reflect.ValueOf(mirroringProp)) && (ok || !reflect.DeepEqual(v, mirroringProp)) {
 		obj["isMirroringCollector"] = mirroringProp
 	}
 	networkTierProp, err := expandComputeForwardingRuleNetworkTier(d.Get("network_tier"), d, config)
@@ -552,7 +555,7 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("all_ports", flattenComputeForwardingRuleAllPorts(res["allPorts"], d)); err != nil {
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}
-	if err := d.Set("mirroring", flattenComputeForwardingRuleMirroring(res["isMirroringCollector"], d)); err != nil {
+	if err := d.Set("mirroring_collector", flattenComputeForwardingRuleMirroring(res["isMirroringCollector"], d)); err != nil {
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}
 	if err := d.Set("network_tier", flattenComputeForwardingRuleNetworkTier(res["networkTier"], d)); err != nil {

--- a/google-beta/resource_compute_forwarding_rule.go
+++ b/google-beta/resource_compute_forwarding_rule.go
@@ -552,6 +552,9 @@ func resourceComputeForwardingRuleRead(d *schema.ResourceData, meta interface{})
 	if err := d.Set("all_ports", flattenComputeForwardingRuleAllPorts(res["allPorts"], d)); err != nil {
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}
+	if err := d.Set("mirroring", flattenComputeForwardingRuleMirroring(res["isMirroringCollector"], d)); err != nil {
+		return fmt.Errorf("Error reading ForwardingRule: %s", err)
+	}
 	if err := d.Set("network_tier", flattenComputeForwardingRuleNetworkTier(res["networkTier"], d)); err != nil {
 		return fmt.Errorf("Error reading ForwardingRule: %s", err)
 	}
@@ -776,6 +779,10 @@ func flattenComputeForwardingRuleLabelFingerprint(v interface{}, d *schema.Resou
 }
 
 func flattenComputeForwardingRuleAllPorts(v interface{}, d *schema.ResourceData) interface{} {
+	return v
+}
+
+func flattenComputeForwardingRuleMirroring(v interface{}, d *schema.ResourceData) interface{} {
 	return v
 }
 

--- a/google-beta/resource_compute_forwarding_rule_test.go
+++ b/google-beta/resource_compute_forwarding_rule_test.go
@@ -206,14 +206,14 @@ resource "google_compute_forwarding_rule" "foobar" {
 func testAccComputeForwardingRule_mirror(backendName, healthchechName, ruleName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar-be" {
-	name        = "%s"
-	health_checks = [google_compute_health_check.foobar-hc.self_link]
+	name        	= "%s"
+	health_checks 	= [google_compute_health_check.foobar-hc.self_link]
 	}
 	
 	resource "google_compute_health_check" "foobar-hc" {
-	name        = "%s"
-	check_interval_sec = 1
-	timeout_sec        = 1
+	name        		= "%s"
+	check_interval_sec 	= 1
+	timeout_sec        	= 1
 	
 	tcp_health_check {
 		port = "80"
@@ -221,18 +221,13 @@ resource "google_compute_region_backend_service" "foobar-be" {
 }
 
 resource "google_compute_forwarding_rule" "foobar" {
-  description = "Resource created for Terraform acceptance testing"
-  ip_protocol = "TCP"
-  name        = "%s"
-  all_ports  = true
-  mirroring   = true
-  backend_service             = google_compute_region_backend_service.foobar-be.self_link
+  description 			= "Resource created for Terraform acceptance testing"
+  ip_protocol 			= "TCP"
+  name        			= "%s"
+  all_ports  			= true
+  mirroring_collector   = true
+  backend_service       = google_compute_region_backend_service.foobar-be.self_link
   load_balancing_scheme = "INTERNAL"
-  network               = "projects/delicate-pangolin-756230/global/networks/dev-host1-vpc"
-  subnetwork            = "projects/delicate-pangolin-756230/regions/us-central1/subnetworks/mirror"
-  labels = {
-    "foo" = "bar"
-  }
 }
 `, backendName, healthchechName, ruleName)
 }

--- a/website/docs/r/compute_forwarding_rule.html.markdown
+++ b/website/docs/r/compute_forwarding_rule.html.markdown
@@ -235,6 +235,12 @@ The following arguments are supported:
   with this forwarding rule. Used with backend service. Cannot be set
   if port or portRange are set.
 
+* `mirroring_collector` -
+  (Optional), [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  For internal TCP/UDP load balancing (i.e. load balancing scheme is
+  INTERNAL and protocol is TCP/UDP), set this to true to allow mirrored packets
+  to be sent to the forwarder.
+
 * `network_tier` -
   (Optional)
   The networking tier used for configuring this address. This field can


### PR DESCRIPTION
Packet mirroring feature in GCP is in beta:
https://cloud.google.com/vpc/docs/packet-mirroring

The feature requires use of a TCP ILB which is enabled for packet mirroring.

This PR adds the option to create a forwarding rule with the mirroring option enabled.