### PR TITLE
provide clearer example for adding multiple labels to a metric

### DIFF
--- a/website/docs/r/logging_metric.html.markdown
+++ b/website/docs/r/logging_metric.html.markdown
@@ -108,9 +108,15 @@ resource "google_logging_metric" "logging_metric" {
       value_type  = "STRING"
       description = "amount of matter"
     }
+    labels {
+      key         = "sku"
+      value_type  = "INT64"
+      description = "Identifying number for item"
+    }
   }
   label_extractors = {
     "mass" = "EXTRACT(jsonPayload.request)"
+    "sku"  = "EXTRACT(jsonPayload.id)"
   }
 }
 ```
@@ -163,7 +169,8 @@ The `metric_descriptor` block supports:
   The set of labels that can be used to describe a specific instance of this metric type. For
   example, the appengine.googleapis.com/http/server/response_latencies metric type has a label
   for the HTTP response code, response_code, so you can look at latencies for successful responses
-  or just for responses that failed.  Structure is documented below.
+  or just for responses that failed. Each `labels` block defines a single metric label but you 
+  have add multiple. Structure is documented below.
 
 * `display_name` -
   (Optional)


### PR DESCRIPTION
When reading the docs for `Logging Metric Counter Labels` on `google_logging_metric` as a newcomer to terraform I stumbled over how to add multiple `labels` as the directive was plural but it appeared to only add a single label. 
I was stepping into an existing terraform project so I had little to no experience.
I believe most people who setup a project from the ground up would have immediately understood but for  someone like me, I think this change would help them understand without adding additional ambiguity