### PR TITLE
Make google_iam_policy page `NOTE` more prominent

### DIFF
--- a/website/docs/d/google_iam_policy.html.markdown
+++ b/website/docs/d/google_iam_policy.html.markdown
@@ -13,6 +13,10 @@ description: |-
 Generates an IAM policy document that may be referenced by and applied to
 other Google Cloud Platform resources, such as the `google_project` resource.
 
+**Note:** Several restrictions apply when setting IAM policies through this API, including some caveats which could cause service interruptions.
+See the [setIamPolicy docs](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setIamPolicy)
+for a list of these restrictions.
+
 ```hcl
 data "google_iam_policy" "admin" {
   binding {
@@ -52,10 +56,6 @@ data "google_iam_policy" "admin" {
 This data source is used to define IAM policies to apply to other resources.
 Currently, defining a policy through a datasource and referencing that policy
 from another resource is the only way to apply an IAM policy to a resource.
-
-**Note:** Several restrictions apply when setting IAM policies through this API.
-See the [setIamPolicy docs](https://cloud.google.com/resource-manager/reference/rest/v1/projects/setIamPolicy)
-for a list of these restrictions.
 
 ## Argument Reference
 


### PR DESCRIPTION
Because of the API the terraform provider uses (at the time of this
writing), defining and applying a google_iam_policy resource will
overwrite any existing policies for the given project. It may be
reasonable to assume that this resource could be additive, so moving
the `NOTE` higher on the page can help reduce issues caused by these
bad assumptions.

Related main provider PR: terraform-providers/terraform-provider-google#5638