### PR TITLE
Fix for terraform-provider-google issue 5608

### DIFF
--- a/google-beta/resource_container_cluster.go
+++ b/google-beta/resource_container_cluster.go
@@ -789,6 +789,11 @@ func resourceContainerCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"label_fingerprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"default_max_pods_per_node": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -1331,6 +1336,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("resource_labels", cluster.ResourceLabels)
+	d.Set("label_fingerprint", cluster.LabelFingerprint)
 
 	if err := d.Set("resource_usage_export_config", flattenResourceUsageExportConfig(cluster.ResourceUsageExportConfig)); err != nil {
 		return err
@@ -1899,8 +1905,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("resource_labels") {
 		resourceLabels := d.Get("resource_labels").(map[string]interface{})
+		labelFingerprint := d.Get("label_fingerprint").(string)
 		req := &containerBeta.SetLabelsRequest{
-			ResourceLabels: convertStringMap(resourceLabels),
+			ResourceLabels:   convertStringMap(resourceLabels),
+			LabelFingerprint: labelFingerprint,
 		}
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)

--- a/website/docs/r/container_cluster.html.markdown
+++ b/website/docs/r/container_cluster.html.markdown
@@ -707,6 +707,8 @@ exported:
 * `instance_group_urls` - List of instance group URLs which have been assigned
     to the cluster.
 
+* `label_fingerprint` - The fingerprint of the set of labels for this cluster.
+
 * `maintenance_policy.0.daily_maintenance_window.0.duration` - Duration of the time window, automatically chosen to be
     smallest possible in the given scenario.
     Duration will be in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format "PTnHnMnS".


### PR DESCRIPTION
Include label fingerprint in resource label update requests for GKE
clusters.

See https://github.com/terraform-providers/terraform-provider-google/issues/5608

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added label_fingerprint
```