### PR TITLE
[DO NOT MERGE] Add support for schema in Healthcare HL7 Stores

### DIFF
--- a/google-beta/resource_healthcare_hl7_v2_store.go
+++ b/google-beta/resource_healthcare_hl7_v2_store.go
@@ -122,7 +122,6 @@ A base64-encoded string.`,
 						"schema": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Computed:     true,
 							AtLeastOneOf: []string{"parser_config.0.allow_null_header", "parser_config.0.segment_terminator", "parser_config.0.schema"},
 							ValidateFunc: validation.ValidateJsonString,
 							StateFunc: func(v interface{}) string {

--- a/google-beta/resource_healthcare_hl7_v2_store.go
+++ b/google-beta/resource_healthcare_hl7_v2_store.go
@@ -15,6 +15,7 @@
 package google
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"reflect"
@@ -22,6 +23,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceHealthcareHl7V2Store() *schema.Resource {
@@ -106,7 +109,7 @@ Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that s
 							Type:         schema.TypeBool,
 							Optional:     true,
 							Description:  `Determines whether messages with no header are allowed.`,
-							AtLeastOneOf: []string{"parser_config.0.allow_null_header", "parser_config.0.segment_terminator"},
+							AtLeastOneOf: []string{"parser_config.0.allow_null_header", "parser_config.0.segment_terminator", "parser_config.0.schema"},
 						},
 						"segment_terminator": {
 							Type:     schema.TypeString,
@@ -114,7 +117,18 @@ Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that s
 							Description: `Byte(s) to be used as the segment terminator. If this is unset, '\r' will be used as segment terminator.
 
 A base64-encoded string.`,
-							AtLeastOneOf: []string{"parser_config.0.allow_null_header", "parser_config.0.segment_terminator"},
+							AtLeastOneOf: []string{"parser_config.0.allow_null_header", "parser_config.0.segment_terminator", "parser_config.0.schema"},
+						},
+						"schema": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: []string{"parser_config.0.allow_null_header", "parser_config.0.segment_terminator", "parser_config.0.schema"},
+							ValidateFunc: validation.ValidateJsonString,
+							StateFunc: func(v interface{}) string {
+								json, _ := structure.NormalizeJsonString(v)
+								return json
+							},
 						},
 					},
 				},
@@ -208,7 +222,11 @@ func resourceHealthcareHl7V2StoreRead(d *schema.ResourceData, meta interface{}) 
 	if err := d.Set("name", flattenHealthcareHl7V2StoreName(res["name"], d, config)); err != nil {
 		return fmt.Errorf("Error reading Hl7V2Store: %s", err)
 	}
-	if err := d.Set("parser_config", flattenHealthcareHl7V2StoreParserConfig(res["parserConfig"], d, config)); err != nil {
+	flattenedParserConfig, err := flattenHealthcareHl7V2StoreParserConfig(res["parserConfig"], d, config)
+	if err != nil {
+		return err
+	}
+	if err := d.Set("parser_config", flattenedParserConfig); err != nil {
 		return fmt.Errorf("Error reading Hl7V2Store: %s", err)
 	}
 	if err := d.Set("labels", flattenHealthcareHl7V2StoreLabels(res["labels"], d, config)); err != nil {
@@ -317,20 +335,26 @@ func flattenHealthcareHl7V2StoreName(v interface{}, d *schema.ResourceData, conf
 	return v
 }
 
-func flattenHealthcareHl7V2StoreParserConfig(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+func flattenHealthcareHl7V2StoreParserConfig(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
 	if v == nil {
-		return nil
+		return nil, nil
 	}
 	original := v.(map[string]interface{})
 	if len(original) == 0 {
-		return nil
+		return nil, nil
 	}
 	transformed := make(map[string]interface{})
 	transformed["allow_null_header"] =
 		flattenHealthcareHl7V2StoreParserConfigAllowNullHeader(original["allowNullHeader"], d, config)
 	transformed["segment_terminator"] =
 		flattenHealthcareHl7V2StoreParserConfigSegmentTerminator(original["segmentTerminator"], d, config)
-	return []interface{}{transformed}
+
+	transformedSchema, err := flattenHealthcareHl7V2StoreParserConfigSchema(original["schema"], d, config)
+	if err != nil {
+		return nil, err
+	}
+	transformed["schema"] = transformedSchema
+	return []interface{}{transformed}, nil
 }
 func flattenHealthcareHl7V2StoreParserConfigAllowNullHeader(v interface{}, d *schema.ResourceData, config *Config) interface{} {
 	return v
@@ -338,6 +362,14 @@ func flattenHealthcareHl7V2StoreParserConfigAllowNullHeader(v interface{}, d *sc
 
 func flattenHealthcareHl7V2StoreParserConfigSegmentTerminator(v interface{}, d *schema.ResourceData, config *Config) interface{} {
 	return v
+}
+
+func flattenHealthcareHl7V2StoreParserConfigSchema(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return string(b), err
 }
 
 func flattenHealthcareHl7V2StoreLabels(v interface{}, d *schema.ResourceData, config *Config) interface{} {
@@ -388,6 +420,14 @@ func expandHealthcareHl7V2StoreParserConfig(v interface{}, d TerraformResourceDa
 		transformed["segmentTerminator"] = transformedSegmentTerminator
 	}
 
+	if v, ok := original["schema"]; ok {
+		transformedSchema, err := expandHealthcareHl7V2StoreParserConfigSchema(v, d, config)
+		if err != nil {
+			return nil, err
+		}
+		transformed["schema"] = transformedSchema
+	}
+
 	return transformed, nil
 }
 
@@ -397,6 +437,18 @@ func expandHealthcareHl7V2StoreParserConfigAllowNullHeader(v interface{}, d Terr
 
 func expandHealthcareHl7V2StoreParserConfigSegmentTerminator(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return v, nil
+}
+
+func expandHealthcareHl7V2StoreParserConfigSchema(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	b := []byte(v.(string))
+	if len(b) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
 }
 
 func expandHealthcareHl7V2StoreLabels(v interface{}, d TerraformResourceData, config *Config) (map[string]string, error) {


### PR DESCRIPTION
Note: this feature is currently in alpha and will be launched shortly (confidentiality no longer needed). The goal of having this PR sent out early is to get early feedback and get this merged in as soon as possible.

The schema is managed as a JSON encoded string similar to bigquery tables due to its compexity and recursive field definitions.

I would like some help in creating the upstream magic modules PR as this has some custom logic that I don't know how to upstream there. Then, I can add an example in the docs and a corresponding test case.