### PR TITLE
makefile changes to run `go generate`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,10 +8,10 @@ GOFLAGS=-mod=vendor
 
 default: build
 
-build: fmtcheck
+build: fmtcheck generate
 	go install
 
-test: fmtcheck
+test: fmtcheck generate
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
@@ -36,6 +36,9 @@ tools:
 	@echo "==> installing required tooling..."
 	go install github.com/client9/misspell/cmd/misspell
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint
+
+generate:
+	go generate  ./...
 
 test-compile:
 	@if [ "$(TEST)" = "./..." ]; then \
@@ -62,5 +65,5 @@ endif
 docscheck:
 	@sh -c "'$(CURDIR)/scripts/docscheck.sh'"
 
-.PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile website website-test docscheck
+.PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile website website-test docscheck generate
 


### PR DESCRIPTION
Updated to just be the makefile changes because everything else will be copied over from MM.

~Part of https://github.com/terraform-providers/terraform-provider-google/issues/6001. After this, the script needs to be added to TPG, and we need to add a `make generate` step to the magician. There's also a bit more cleanup around product names I'd like to do in MM.~

~This is the meat of the change- the actual script to do the generation. Because of upcoming MMv2 and the beta/GA distinction making it hard to know which handwritten website files to include in the sidebar, I opted to generate it in TPG(B), where we know exactly which files should be included, instead of in MM.~

~It's hard to tell what's actually going on from the GitHub diff, so I ran `make website` from this branch and from master and put the diff into a [doc](https://docs.google.com/document/d/1RokF69DqXW4oxXEen0HMqts90wN1aQ8Wj9H7MTFJGQM/edit?hl=en)~