### PR TITLE
Added optional components: HBASE, RANGER, SOLR

### DIFF
--- a/google-beta/resource_dataproc_cluster.go
+++ b/google-beta/resource_dataproc_cluster.go
@@ -452,7 +452,7 @@ by Dataproc`,
 										Elem: &schema.Schema{
 											Type: schema.TypeString,
 											ValidateFunc: validation.StringInSlice([]string{"COMPONENT_UNSPECIFIED", "ANACONDA", "DRUID", "HIVE_WEBHCAT",
-												"JUPYTER", "KERBEROS", "PRESTO", "ZEPPELIN", "ZOOKEEPER"}, false),
+												"HBASE", "HIVE_WEBHCAT", "JUPYTER", "PRESTO", "RANGER", "SOLR", "ZEPPELIN", "ZOOKEEPER"}, false),
 										},
 									},
 								},

--- a/website/docs/r/dataproc_cluster.html.markdown
+++ b/website/docs/r/dataproc_cluster.html.markdown
@@ -438,10 +438,13 @@ cluster_config {
     Accepted values are:
     * ANACONDA
     * DRUID
+    * HBASE
     * HIVE_WEBHCAT
     * JUPYTER
     * KERBEROS
     * PRESTO
+    * RANGER
+    * SOLR
     * ZEPPELIN
     * ZOOKEEPER
 


### PR DESCRIPTION
Hello

I added three missing beta Optional Components to the Dataproc resource.
[This is the current list of Optional Components](https://cloud.google.com/dataproc/docs/concepts/components/overview#available_optional_components).

Cheers