### PR TITLE
Force new clusters on changes to Workload Identity parameters.

### DIFF
--- a/google-beta/resource_container_cluster.go
+++ b/google-beta/resource_container_cluster.go
@@ -886,6 +886,8 @@ func resourceContainerCluster() *schema.Resource {
 						"identity_namespace": {
 							Type:     schema.TypeString,
 							Required: true,
+							// The GCP API allows this to be mutated in-place, but that has no effect.
+							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
The GCP API allows this to be changed in place, but it doesn't take
effect, so we should force cluster rebuilds.

I used Terraform on one of my clusters to turn on Workload Identity. I'd heard I needed to make a new cluster but TF offered to change the setting in-place, and the application was successful: GCP didn't reject the request, and the setting was visible on the cluster afterwards. However it simply doesn't work; Pods with Workload Identity correctly configured continue to use the Node's Instance Service Account. I lost a lot of time debugging this and don't want anyone else to suffer the same.