### PR TITLE
docs: redis_instance: supports REDIS_5_0

### DIFF
--- a/website/docs/r/redis_instance.html.markdown
+++ b/website/docs/r/redis_instance.html.markdown
@@ -198,6 +198,7 @@ The following arguments are supported:
   (Optional)
   The version of Redis software. If not provided, latest supported
   version will be used. Currently, the supported values are:
+  - REDIS_5_0 for Redis 5.0 compatibility
   - REDIS_4_0 for Redis 4.0 compatibility
   - REDIS_3_2 for Redis 3.2 compatibility
 


### PR DESCRIPTION
According to the [official docs](https://cloud.google.com/memorystore/docs/redis/upgrading-instance-version) v5.0 is supported – update the docs that `REDIS_5_0` is a valid value for version.